### PR TITLE
Remove visual identity paragraph

### DIFF
--- a/projects/02-data-lovers/README.md
+++ b/projects/02-data-lovers/README.md
@@ -87,11 +87,6 @@ y cada persona está representada como un _objeto_ con una _propiedad_ `altura`,
 podríamos elegir calcular la altura promedio en el grupo entre otras cosas.
 --->
 
-Algunos sets de datos tiene una identidad gráfica que deberás utilizar en la
-interfaz. La identidad gráfica, también conocida como guía de estilos en
-diseño, de estos sets la podrás encontrar en el siguiente
-[link](https://drive.google.com/open?id=1eeWFqrWpy-OYOH4EHDckFGunyrm9iNeE).
-
 ## 3. Objetivos de aprendizaje
 
 El objetivo principal de este proyecto es que aprendas a diseñar y construir una
@@ -212,7 +207,7 @@ Tus _pruebas unitarias_ deben dar una cobertura del 70% de _statements_
 (_ramas_) del archivo `src/data.js` que contenga tus funciones y está detallado
 en la sección de [Consideraciones técnicas](#srcdatajs).
 
-## 6. Hacker edition  
+## 6. Hacker edition
 
 Las secciones llamadas _Hacker Edition_ son **opcionales**. Si **terminaste**
 con todo lo anterior y te queda tiempo, intenta completarlas. Así podrás

--- a/projects/02-data-lovers/README.pt-BR.md
+++ b/projects/02-data-lovers/README.pt-BR.md
@@ -85,10 +85,6 @@ y cada persona está representada como un _objeto_ con una _propiedad_ `altura`,
 podríamos elegir calcular la altura promedio en el grupo entre otras cosas.
 --->
 
-Alguns conjuntos de dados têm uma identidade gráfica que você deverá utilizar
-na interface. Os guias de identidade gráfica podem ser encontrados neste
-[link](https://drive.google.com/open?id=1eeWFqrWpy-OYOH4EHDckFGunyrm9iNeE).
-
 ## 3. Objetivos de aprendizagem
 
 O objetivo principal deste projeto é que aprenda a desenhar e construir uma


### PR DESCRIPTION
closes #838 

Although the files that were shared somehow could help the students to have an idea of what to expect of this project. Using `.sketch` or `.psd` files could restrict their ability to access  those resources (not everyone has the propietary software to open them). And while there was one that had a `.pdf` extension, we could create a bias towards using that data-set instead of the others without a visual identity.

Let's take a step back and rethink the benefits of providing these files and the format in which we can share them.