### PR TITLE
chore(projects): Replaces project specific assessment section with generic text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,17 @@ El _bootcamp_ de [Laboratoria](https://www.laboratoria.la/) es un **programa de
 aprendizaje inmersivo de 6 meses** enfocado en los perfiles de **Front-end
 Developer** y **UX Designer**.
 
-Nuestro modelo de aprendizaje se basa en emular un ambiente laboral que prepare
-a nuestras estudiantes desarrollando habilidades técnicas y socioemocionales
-fundamentales para comenzar a trabajar.
+Nuestro modelo de aprendizaje se basa en simular un ambiente laboral que te
+prepare desarrollando habilidades técnicas y socioemocionales necesarias para
+**comenzar** a trabajar.
 
-El **aprendizaje basado en proyectos** es el eje central sobre el que se
-articula la experiencia de aprendizaje. Completar una serie de _proyectos_, de
-complejidad gradualmente creciente, permite a las estudiantes ir desarrollando
-las habilidades necesarias. De todas estas habilidades, consideramos que el
-**Autoaprendizaje** es la más importante; creemos firmemente que, no solamente
-es una habilidad indispensable para el mundo laboral que les espera, si no que
-es también una poderosa herramienta para que sean mujeres autosuficientes,
-seguras de su talento y habilidades y, finalmente, agentes de cambio a largo
-plazo.
+El **aprendizaje basado en proyectos** es el eje central de la experiencia de
+aprendizaje de nuestro _bootcamp_. Trabajar en una serie de _proyectos_, de
+complejidad gradualmente creciente, te permitirá ir desarrollando las
+habilidades necesarias; de todas las habilidades, consideramos que el
+**Autoaprendizaje** es la más importante; no sólo es una habilidad
+indispensable para el trabajo que te espera, si no que es también una poderosa
+herramienta para autosuficiente, segura de tu talento y habilidades.
 
 ## Mapa de proyectos
 
@@ -49,40 +47,39 @@ trivia |        > data-lovers |   md-links > social-network    burger-queen-api 
 
 ## Evaluación
 
-Durante el transcurso de cada proyecto nuestro equipo de coaches hará
-seguimiento de tu avance (o de tu equipo si el proyecto es en grupo).
+Durante el transcurso de cada proyecto nuestro equipo de _coaches_ hará un
+seguimiento **individual** de tu trabajo y el de tu equipo (si es en grupo).
 
 El tiempo estimado para completar un proyecto puede variar dependiendo de cómo
-vayas avanzando. Asegúrate de conversar con tus coaches para que te ayuden a
-planificar y definir el alcance de lo que quieras implementar. Recuerda que
-**los objetivos de aprendizaje son más importantes que la completitud de tu
+vayas avanzando y aprendiendo. Asegúrate de conversar con tus _coaches_ para que
+te ayuden a planificar y definir el alcance de lo que quieras y necesites
+implementar para conseguir los objetivos de aprendizaje del proyecto. Recuerda
+que **los objetivos de aprendizaje son más importantes que la completitud de tu
 proyecto**.
 
-Al final del proyecto, tendrás una _sesión de feedback_ con tus coaches. Antes
-de esta sesión de feedback tendrás que reflexionar y autoevaluarte con respecto
-a los objetivos de aprendizaje. En la sesión de feedback validarás esa
-autoevaluación con tus coaches. En caso de no haberse completado algunos
-objetivos podrá ocurrir una de las siguientes:
+Al final del proyecto, tendrás una _sesión de feedback_ con tus _coaches_. Antes
+de esta sesión tendrás que reflexionar y autoevaluarte respecto a los objetivos
+de aprendizaje. En esta sesión de _feedback_ validarás tu autoevaluación con tus
+_coaches_. En caso de no haber conseguido algunos objetivos, podrá ocurrir:
 
 * Si se trata de objetivos de aprendizaje que vuelven a aparecer más adelante en
-  otros proyectos, simplemente quedarán anotados como _pendiente_ en los
-  siguientes proyectos y podrás continuar con el siguiente proyecto.
-* En caso contrario tus coaches te recomendarán cómo continuar para alcanzar los
-  objetivos de aprendizaje que te faltan, pudiendo ser a través de continuar con
-  el proyecto (más tiempo), hacer ejercicios enfocados en los temas necesarios,
-  etc, ...
+  otros proyectos, pueden quedar simplemente anotados como _pendiente_ y podrás
+  continuar con otro proyecto.
+* En caso contrario, tus _coaches_ te recomendarán cómo seguir para alcanzar los
+  objetivos de aprendizaje que te falten, pudiendo ser a través de continuar con
+  el proyecto (más tiempo), hacer un proyecto complementario, etc.
 
 Recuerda que cada una aprende a su ritmo y lo importante es ir obteniendo las
 habilidades asociadas a los objetivos de aprendizaje de forma gradual. Tus
-coaches y compañeras están ahí para apoyarte.
+_coaches_ y compañeras están ahí para apoyarte.
 
 ***
 
 ## Etapa 0: Preadmisión
 
-La etapa de _admisión_ empieza _antes_ de ser aceptada a nuestro Bootcamp. Al
+La etapa de _admisión_ empieza _antes_ de ser aceptada a nuestro _bootcamp_. Al
 final de cada _proceso de admisión_ invitaremos a candidatas preseleccionadas a
-completar un _proyecto_ presencialmente en una de nuestras sedes.
+completar presencialmente un _proyecto_ en una de nuestras sedes.
 
 ### Proyecto: Trivia (necesita refactorización)
 
@@ -96,17 +93,16 @@ completar un _proyecto_ presencialmente en una de nuestras sedes.
 ## Etapa 1: Common Core
 
 Todas las estudiantes admitidas, comienzan con el _common core_. Durante esta
-etapa completarán dos _proyectos_:
+etapa trabajarás en dos _proyectos_:
 
-1. Primero pudiendo elegir entre [Cifrado César](projects/01-cipher) y
-   [Tarjeta de crédito válida](projects/01-card-validation). Ambos proyectos
+1. Primero puedes elegir entre [Cifrado César](projects/01-cipher) y
+   [Tarjeta de Crédito Válida](projects/01-card-validation). Ambos proyectos
    comparten los mismos objetivos de aprendizaje.
-2. Una vez completado el proyecto elegido en el punto anterior, tendrán que
-   completar el proyecto [Data Lovers](projects/02-data-lovers).
+2. Después, tendrás que trabajar en [Data Lovers](projects/02-data-lovers).
 
-Al final del _common core_ las estudiantes participan en una o más
-_hackathones_ trabajando en proyectos más pequeños propuestos por Laboratoria
-y/o empresas/empleadores externos.
+Al final del _common core_ participarás en una o más _hackathones_ trabajando
+en proyectos más pequeños propuestos por Laboratoria y/o
+empresas/empleadores externos.
 
 ### Proyecto: [Cifrado César](projects/01-cipher)
 
@@ -117,12 +113,12 @@ El principal objetivo de aprendizaje de este proyecto es tener una primera
 experiencia construyendo una aplicación web, utilizando los conocimientos
 adquiridos sobre **User Experience Design** y **JavaScript**. Esto incluye
 diseñar un producto pensando en los usuarios, construir una interfaz, escuchar
-eventos básicos del DOM, escribir lógica para llevar a cabo el cifado y
+eventos básicos del DOM, escribir lógica para llevar a cabo el cifrado y
 descifrado, _tests_ unitarios básicos para comprobar (y documentar) dicha
 lógica, y manipulación del DOM para mostrar (escribir) los resultados.
 
 * Duración estimada: 2 semanas.
-* Equipos: 1 estudiante.
+* Equipos: 1 estudiante (individual).
 * Tópicos: [Flow control](topics/javascript/02-flow-control),
   [Strings](topics/javascript/06-strings), [Testing](topics/testing),
   [HTML](topics/html), [SCM](topics/scm), [Shell](topics/shell),
@@ -130,7 +126,7 @@ lógica, y manipulación del DOM para mostrar (escribir) los resultados.
 
 ### Proyecto: [Tarjeta de crédito válida](projects/01-card-validation)
 
-Este _proyecto_ require implementar una aplicación web basada un _boilerplate_
+Este _proyecto_ requiere implementar una aplicación web basada un _boilerplate_
 que permita a un usuario validar el número de una tarjeta de crédito y además
 ocultar todos los dígitos de la tarjeta menos los últimos cuatro.
 
@@ -138,12 +134,12 @@ El principal objetivo de aprendizaje de este proyecto es tener una primera
 experiencia construyendo una aplicación web, utilizando los conocimientos
 adquiridos sobre **User Experience Design** y **JavaScript**. Esto incluye
 diseñar un producto pensando en los usuarios, construir una interfaz, escuchar
-eventos básicos del DOM, escribir lógica para llevar a cabo el cifado y
+eventos básicos del DOM, escribir lógica para llevar a cabo el cifrado y
 descifrado, _tests_ unitarios básicos para comprobar (y documentar) dicha
 lógica, y manipulación del DOM para mostrar (escribir) los resultados.
 
 * Duración estimada: 2 semanas.
-* Equipos: 1 estudiante.
+* Equipos: 1 estudiante (individual).
 * Tópicos: [Flow control](topics/javascript/02-flow-control),
   [Strings](topics/javascript/06-strings), [Testing](topics/testing),
   [HTML](topics/html), [SCM](topics/scm), [Shell](topics/shell),
@@ -151,19 +147,18 @@ lógica, y manipulación del DOM para mostrar (escribir) los resultados.
 
 ### Proyecto: [Data Lovers](projects/02-data-lovers)
 
-En este proyecto tendrán su primer acercamiento a transformar _data_ en
+En este proyecto tendrás tu primer acercamiento a transformar _data_ en
 información. El objetivo principal de este proyecto es aprender a diseñar y
 construir una _interfaz web_ donde podamos visualizar y manipular _data_.
 
 Esperamos que puedan pensar en el usuario, entender cuál es la mejor manera de
-visualizar la data según sus necesidades, y plasmar todo eso en el diseño en
-la web.
+visualizar la data en la web según sus necesidades.
 
-Este proyecto se debe "resolver" en parejas, por lo que un objetivo importante
-es ganar experiencia en trabajos colaborativos con toda la complejidad que
+Este proyecto se debe "resolver" en duplas, por lo que un objetivo importante
+es ganar experiencia en trabajo colaborativo con toda la complejidad que
 eso implica.
 
-* Duración estimada: 3 semanas.
+* Duración estimada: 4 semanas.
 * Equipos: 2 estudiantes.
 * Tópicos: [Arrays](topics/javascript/04-arrays),
   [Objects](topics/javascript/05-objects), [DOM](topics/browser/02-dom),
@@ -176,21 +171,21 @@ eso implica.
 Después del _common core_ cada grupo se separa en _tracks especializados_ y
 paralelos: _Front-end Development y UX Design_.
 
-### Track Front End Dev
+### Track Front-end Development
 
-Tópicos comunes (independientes de proyecto): [Paradigmas](topics/paradigms),
+Tópicos comunes (uno o más proyectos): [Paradigmas](topics/paradigms),
 [JavaScript Funcional](topics/functional).
 
 #### Proyecto: [Red Social](projects/03-social-network)
 
 En este _proyecto_ partimos del supuesto que una emprendedora ha pedido hacer
-un prototipo para una _red social_ sobre algunos temas de entre los cuales las
-estudiantes deberán elegir.
+un prototipo para una _red social_ sobre algunos temas de entre los cuales
+deberás elegir.
 
-El objetivo principal de aprendizaje de este proyecto es construir un sitio web
+El objetivo de aprendizaje principal de este proyecto es construir un sitio web
 [_responsive_](https://github.com/Laboratoria/bootcamp/tree/master/topics/css/02-responsive)
-con más de una vista (página), y en el que podamos leer y escribir datos,
-entendiendo las necesidades de los usuarios para los que sw creará el producto.
+con más de una vista (página), y en el que podamos leer y escribir datos
+entendiendo las necesidades de los usuarios.
 
 * Duración estimada: 3 semanas.
 * Equipos: 3 estudiantes.
@@ -203,15 +198,15 @@ entendiendo las necesidades de los usuarios para los que sw creará el producto.
 Dentro de una comunidad de código abierto, proponen crear una herramienta
 usando [Node.js](https://nodejs.org/), que lea y analice archivos en formato
 `Markdown`, para verificar los links que contengan y reportar
-algunas estadísticas.
+algunas estadísticas al respecto.
 
 El objetivo práctico de este proyecto es aprender a crear una **librería**
 (o biblioteca - _library_) en JavaScript.
 
 Diseñar una librería es una experiencia fundamental para cualquier
 desarrolladora porque que le obliga a pensar en la interfaz (API) de sus
-_módulos_ y cómo será usada por otros developers. Se necesita tener especial
-consideración en peculiaridades del lenguaje, convenciones y buenas prácticas.
+_módulos_ y cómo será usada por otros _developers_. Se necesita tener especial
+consideración en peculiaridades del lenguaje, convenciones y "buenas prácticas".
 
 * Duración estimada: 3 semanas.
 * Equipos: 1 estudiante.
@@ -224,7 +219,7 @@ Este _proyecto_ requiere implementar un sistema para que lxs meserxs de un
 restautante (_Burger Queen_) puedan tomar nota de los pedidos usando una
 _tablet_.
 
-El objetivo principal de aprendizaje de este proyecto es construir una
+El objetivo de aprendizaje principal de este proyecto es construir una
 _interfaz web_ usando un _framework_ (React, Vue o Angular).
 
 Como objetivo secundario, la implementación debe seguir las recomendaciones
@@ -237,10 +232,10 @@ para PWAs (_Progressive Web Apps_), lo cual incluye conceptos como **offline**.
 
 #### Proyecto: [Burger Queen HTTP/JSON API](projects/04-burger-queen-api)
 
-El objetivo principal de aprendizaje es adquirir experiencia con **Node.js**
+El objetivo de aprendizaje principal es adquirir experiencia con **Node.js**
 como herramienta para desarrollar _aplicaciones de servidor_, junto con una
 serie de herramientas comunes usadas en este tipo de contexto (Express como
-framework, MongoDB como base datos, ...).
+_framework_, MongoDB como base datos, etc.).
 
 En este proyecto tendrás que construir un servidor web que debe _servir_ `JSON`
 sobre `HTTP`.
@@ -279,13 +274,12 @@ para PWAs (_Progressive Web Apps_), lo cual incluye conceptos como **offline**.
 
 #### Proyecto: [Emprendimientos](projects/03-small-businesses)
 
-Para este reto inicial del track, las estudiantes trabajan con pequeños
-emprendimientos buscando ofrecer una nueva y/o mejor experiencia online.
-Para ello, tienen que entender los objetivos de negocio y también las
-necesidades de los usuarios/clientes de estos emprendimientos. Durante este
-reto las estudiantes hacen trabajo de campo como entrevistas, observación y
-testing. Y diseñan soluciones utilizando herramientas de diseño como Figma y
-Marvel.
+Para este proyecto inicial del _track_, trabajarás con pequeños emprendimientos
+para ofrecer una nueva y/o mejor experiencia _online_ para sus usuarios. Para
+eso, tienes que entender los objetivos de negocio del emprendimiento y las
+necesidades de sus usuarios/clientes. Durante este proyecto harás trabajo de
+campo: entrevistas, observación y _testing_ y diseñarás soluciones utilizando
+herramientas de diseño como Figma y Marvel.
 
 * Duración estimada: 3 semanas
 * Equipos: 2 o 3 estudiantes
@@ -293,12 +287,14 @@ Marvel.
   (flujo de contenido, mapa de sitio), diseño visual y de interacción
   (wireframes y prototipado), y user testing
 
-#### Proyecto: [Rediseño y análisis de data](projects/04-redesign-and-data)
+#### Proyecto: [Rediseño y Análisis de Data](projects/04-redesign-and-data)
 
-Este es un proyecto de rediseño. Basándose en la data de los resultados
-que está teniendo una aplicación de servicios financieros, las estudiantes
-buscan mejorar la experiencia de la misma. En algunas casos este reto puede ser reemplazado por un reto con una empresa, pero con los mismos objetivos de
-aprendizaje.
+Este es un proyecto de rediseño de un producto existente. Basándose en la data
+de los resultados que está teniendo una aplicación de servicios financieros,
+deberás mejorar la experiencia de la misma.
+
+En algunas casos este proyecto puede ser reemplazado por un uno con una
+empresa, pero tendrá siempre los mismos objetivos de aprendizaje.
 
 * Duración estimada: 3 semanas
 * Equipos: 2 o 3 estudiantes
@@ -306,10 +302,9 @@ aprendizaje.
 
 #### Proyecto: [Consultoría UX](projects/05-ux-consultancy)
 
-En este reto, las estudiantes trabajan en distintos casos reales
-propuestos por empresas de diversos rubros y tamaños. Anteriores retos
-han incluido empresas como Kmimos, Guvery, Globant, Sinenvolturas,
-Magical Startups, Laboratoria, entre otras.
+Trabajarás en distintos casos reales propuestos por empresas de diversos rubros
+y tamaños. En el pasado se ha trabajado con empresas como Kmimos, Guvery,
+Globant, Sinenvolturas, Magical Startups, Laboratoria, entre otras.
 
 * Duración estimada: 3 semanas
 * Equipos: Depende de proyectos
@@ -317,27 +312,24 @@ Magical Startups, Laboratoria, entre otras.
 
 ***
 
-## Etapa 3: Capstone / Electivos
+## Etapa 3: Electivos
 
-El último mes del Bootcamp - más o menos, cada una avanza a su ritmo - se espera
-que construyas tu proyecto _final_ o _capstone_, que puede estar basado en los
-tópicos/tecnologías vistas hasta el momento, o pueden cubrir algunos de los
-tópicos sugeridos (electivos).
+La última parte del _bootcamp_, y dependiendo de cómo hayas conseguido los
+objetivos de aprendizaje de los anteriores proyectos, podrás aprovechar para
+elegir trabajar en un proyecto _final_ que puede estar basado en los
+tópicos/tecnologías vistas hasta el momento, o puede cubrir algunos de los
+tópicos adicionales sugeridos.
 
-### Track Front End Dev
+### Track Front-end Development
 
-#### Proyecto: [Tic tac toe con React Native](projects/05-tic-tac-toe-rn)
+#### Proyecto: [Tic Tac Toe Con React Native](projects/05-tic-tac-toe-rn)
 
-El objetivo principal de aprendizaje es tener una primera experiencia en
-desarrollo de aplicaciones nativas con React Native.
+El objetivo de aprendizaje principal es tener una primera experiencia en
+desarrollo de una aplicación usando React Native y Expo, y publicarla en tu
+cuenta de Expo para que se pueda instalar en cualquier dispositivo Android o iOS.
 
-En este proyecto tendrás que construir una aplicación usando React Native y
-Expo, y publicarla en tu cuenta de Expo, para que se pueda instalar en cualquier
-dispositivo Android o iOS.
-
-Para completar el proyecto tendrás que familiarizarte con conceptos como `View`,
-`Text` o `TouchableOpacity`, además del flujo de desarrollo propio de apps
-nativas.
+Tendrás que familiarizarte con conceptos como `View`, `Text` o
+`TouchableOpacity` y con el flujo de desarrollo propio de apps nativas.
 
 * Duración estimada: 2 semanas.
 * Equipos: 1 estudiante
@@ -346,12 +338,12 @@ nativas.
 #### Proyecto: [Battleship](projects/05-battleship)
 
 Battleship es un juego clásico, con múltiples versiones en juegos de mesa y en
-linea (si no lo conoces, puedes verlo en este link :
+línea (si no lo conoces, puedes verlo en este link :
 [battle-ship](https://es.wikipedia.org/wiki/Batalla_naval_(juego))).
 
 En este proyecto deberás crear una nueva versión, agregándole algún giro para
-actualizarlo y hacerlo más atractivo para las nuevas generaciones. También, no
-estás atada a hacer este juego sobre barcos, puedes hacerlo con el tema que más
+actualizarlo y hacerlo más atractivo para las nuevas generaciones. No estás
+atada a hacer este juego sobre barcos, puedes hacerlo con el tema que más
 te guste, siempre y cuando el modo de juego sea parecido.
 
 * Duración estimada: 2 semanas.
@@ -362,14 +354,15 @@ te guste, siempre y cuando el modo de juego sea parecido.
 
 #### Proyecto: [Visual Design](projects/06-visual-design)
 
-En este reto buscamos mejorar las habilidades de diseño visual de interfaces.
-Para ello, las estudiantes trabajan en cómo mejorar y unificar la experiencia
-de una plataforma de venta de entradas a espectaculos (tradicional) para
-ayudarlos a competir con nuevos actores en la industria como Stubhub,
-Eventbrite, Joinnus, entre otros. Para ello tendrán que crear soluciones
-consistentes para mobile, desktop y smartwatches.  En algunas casos este reto
-puede ser reemplazado por un reto con una empresa, pero con los mismos
-objetivos de aprendizaje.
+En este proyecto buscamos mejorar las habilidades de diseño visual de interfaces.
+Para ello, las trabajarás en cómo mejorar y unificar la experiencia de una
+plataforma de venta de entradas a espectáculos (tradicional) para ayudarlos a
+competir con nuevos actores en la industria como Stubhub, Eventbrite, Joinnus,
+entre otros.
+
+Tendrán que crear soluciones consistentes para _mobile_, _desktop_ y
+_smartwatches_. En algunas casos este proyecto puede ser reemplazado por uno
+con una empresa, pero con los mismos objetivos de aprendizaje.
 
 * Duración estimada: 3 semanas
 * Equipos: Depende de proyectos
@@ -379,9 +372,9 @@ objetivos de aprendizaje.
 #### Proyecto: [Service Design](projects/06-service-design)
 
 Con la ayuda de consultoras especializadas como Amable o Touchpoint,
-las estudiantes se sumergen en el mundo del service design. Entendiendo
-problemas de negocio desde una visión más holística y utilizando
-nuevas herramientas como el Service BluePrint.
+te sumergirás  en el mundo del _service design_ (diseño de servicios)
+entendiendo problemas de negocio desde una visión más holística y utilizando
+nuevas herramientas como el _Service BluePrint_.
 
 * Duración estimada: 3 semanas
 * Equipos: Depende de proyectos

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 ## Introducción
 
-El _bootcamp_ de Laboratoria es un **programa de aprendizaje inmersivo de 6
-meses** enfocado en los perfiles de **Front-end Developer** y **UX Designer**.
+El _bootcamp_ de [Laboratoria](https://www.laboratoria.la/) es un **programa de
+aprendizaje inmersivo de 6 meses** enfocado en los perfiles de **Front-end
+Developer** y **UX Designer**.
+
 Nuestro modelo de aprendizaje se basa en emular un ambiente laboral que prepare
-a nuestras estudiantes desarrollando las habilidades técnicas y socioemocionales
-que necesitan para comenzar a trabajar.
+a nuestras estudiantes desarrollando habilidades técnicas y socioemocionales
+fundamentales para comenzar a trabajar.
 
 El **aprendizaje basado en proyectos** es el eje central sobre el que se
 articula la experiencia de aprendizaje. Completar una serie de _proyectos_, de
@@ -21,11 +23,10 @@ es también una poderosa herramienta para que sean mujeres autosuficientes,
 seguras de su talento y habilidades y, finalmente, agentes de cambio a largo
 plazo.
 
-## Mapa de aprendizaje
+## Mapa de proyectos
 
-El _mapa de aprendizaje_ (o _mapa de proyectos_ se divide en 4 _etapas_:
-**Preadmisión**, **Common Core**, **Track** (Front-end Development y UX Design)
-y **Electivos**.
+El _mapa de proyectos_ se divide en 4 _etapas_: **Admisión**, **Common Core**,
+**Track** (Front-end Development y UX Design) y **Electivos**.
 
 ```
 Pre    | Common Core          | Track                                                   | Electivos      |
@@ -45,6 +46,35 @@ trivia |        > data-lovers |   md-links > social-network    burger-queen-api 
        |                      |                                                         | visual-design  |
        |                      |                                                         |                |
 ```
+
+## Evaluación
+
+Durante el transcurso de cada proyecto nuestro equipo de coaches hará
+seguimiento de tu avance (o de tu equipo si el proyecto es en grupo).
+
+El tiempo estimado para completar un proyecto puede variar dependiendo de cómo
+vayas avanzando. Asegúrate de conversar con tus coaches para que te ayuden a
+planificar y definir el alcance de lo que quieras implementar. Recuerda que
+**los objetivos de aprendizaje son más importantes que la completitud de tu
+proyecto**.
+
+Al final del proyecto, tendrás una _sesión de feedback_ con tus coaches. Antes
+de esta sesión de feedback tendrás que reflexionar y autoevaluarte con respecto
+a los objetivos de aprendizaje. En la sesión de feedback validarás esa
+autoevaluación con tus coaches. En caso de no haberse completado algunos
+objetivos podrá ocurrir una de las siguientes:
+
+* Si se trata de objetivos de aprendizaje que vuelven a aparecer más adelante en
+  otros proyectos, simplemente quedarán anotados como _pendiente_ en los
+  siguientes proyectos y podrás continuar con el siguiente proyecto.
+* En caso contrario tus coaches te recomendarán cómo continuar para alcanzar los
+  objetivos de aprendizaje que te faltan, pudiendo ser a través de continuar con
+  el proyecto (más tiempo), hacer ejercicios enfocados en los temas necesarios,
+  etc, ...
+
+Recuerda que cada una aprende a su ritmo y lo importante es ir obteniendo las
+habilidades asociadas a los objetivos de aprendizaje de forma gradual. Tus
+coaches y compañeras están ahí para apoyarte.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ complejidad gradualmente creciente, te permitirá ir desarrollando las
 habilidades necesarias; de todas las habilidades, consideramos que el
 **Autoaprendizaje** es la más importante; no sólo es una habilidad
 indispensable para el trabajo que te espera, si no que es también una poderosa
-herramienta para autosuficiente, segura de tu talento y habilidades.
+herramienta para ser autosuficiente, segura de tu talento y habilidades.
 
 ## Mapa de proyectos
 

--- a/projects/01-card-validation/README.md
+++ b/projects/01-card-validation/README.md
@@ -7,8 +7,7 @@
 * [3. Objetivos de aprendizaje](#3-objetivos-de-aprendizaje)
 * [4. Consideraciones generales](#4-consideraciones-generales)
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
-* [6. Evaluación](#6-evaluación)
-* [7. Pistas, tips y lecturas complementarias](#7-pistas-tips-y-lecturas-complementarias)
+* [6. Pistas, tips y lecturas complementarias](#6-pistas-tips-y-lecturas-complementarias)
 
 ***
 
@@ -29,10 +28,10 @@ la suma de sus dígitos finales es un múltiplo de 10.
 
 ## 2. Resumen del proyecto
 
-¿Qué tengo que hacer exactamente? En este proyecto tendrás que construir una
-aplicación web que le permita a un usuario validar el número de una tarjeta de
-crédito. Además de ocultar todos los dígitos de la tarjeta menos los últimos
-cuatro dígitos.
+En este proyecto tendrás que construir una aplicación web que le permita a un
+usuario validar el número de una tarjeta de crédito. Además, tendrás que
+implementar funcionalidad para ocultar todos los dígitos de una tarjeta menos
+los últimos cuatro.
 
 La temática es libre. Tú debes pensar en qué situaciones de la vida real se
 necesitaría validar una tarjeta de crédito y pensar en cómo debe ser esa
@@ -219,55 +218,9 @@ Tus pruebas unitarias deben dar un 70% en _coverage_ (cobertura),
 _statements_ (sentencias), _functions_ (funciones) y _lines_ (líneas); y un
 mínimo del 50% de _branches_ (ramas).
 
-## 6. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 2              |
-| Autoaprendizaje                                 | 2              |
-| Presentaciones                                  | 2              |
-| Adaptabilidad                                   | 2              |
-| Solución de problemas                           | 2              |
-| Responsabilidad                                 | 2              |
-| Dar y recibir feedback                          | 2              |
-| Comunicación eficaz                             | 2              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Source Code Management (SCM)**                         |
-| Git                                     | 1              |
-| GitHub                                  | 2              |
-| **JavaScript**                                           |
-| Nomenclatura / semántica                | 2              |
-| Tests                                   | 2              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 2              |
-| Semántica / Arquitectura de información | 2              |
-| DRY (CSS)                               | 2              |
-| Responsive Web Design                   | 2              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 2              |
-
 ***
 
-## 7. Pistas, tips y lecturas complementarias
+## 6. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 

--- a/projects/01-cipher/README.md
+++ b/projects/01-cipher/README.md
@@ -9,9 +9,8 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Consideraciones técnicas](#7-consideraciones-técnicas)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -216,55 +215,9 @@ entorno (browser en este caso) y las [reglas recomendadas (`"eslint:recommended"
 En cuanto a reglas/guías de estilo en sí,
 usaremos las recomendaciones _por defecto_ de tanto `eslint` como `htmlhint`.
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 2              |
-| Autoaprendizaje                                 | 2              |
-| Presentaciones                                  | 2              |
-| Adaptabilidad                                   | 2              |
-| Solución de problemas                           | 2              |
-| Responsabilidad                                 | 2              |
-| Dar y recibir feedback                          | 2              |
-| Comunicación eficaz                             | 2              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Source Code Management (SCM)**                         |
-| Git                                     | 1              |
-| GitHub                                  | 2              |
-| **JavaScript**                                           |
-| Nomenclatura / semántica                | 2              |
-| Tests                                   | 2              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 2              |
-| Semántica / Arquitectura de información | 2              |
-| DRY (CSS)                               | 2              |
-| Responsive Web Design                   | 2              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 2              |
-
 ***
 
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 
@@ -333,7 +286,7 @@ Organización del Trabajo:
   poco a lo largo del -_bootcamp_.
 * [Guía para Cifrado César](https://docs.google.com/presentation/d/e/2PACX-1vTQ7-8LZDHrT4Y6AOBN72Nkfz1eJAeseBHpcHX8BSq0aFCFoZmuMjluMeyFNgK9ISKxTz0H03yGfJiT/pub?start=false&loop=false&delayms=60000)
 
-## 10. Checklist
+## 9. Checklist
 
 Esta sección está para ayudarte a llevar un control de lo que vas completando.
 

--- a/projects/01-cipher/README.pt-BR.md
+++ b/projects/01-cipher/README.pt-BR.md
@@ -6,14 +6,11 @@
 * [2. Resumo do projeto](#2-resumo-do-projeto)
 * [3. Objetivos de aprendizagem](#3-objetivos-de-aprendizagem)
 * [4. Considerações gerais](#4-considerações-gerais)
-* [5. Critérios de aceitação mínimos do
-  projeto](#5-criterios-de-aceitação-mínimos-do-projeto)
+* [5. Critérios de aceitação mínimos do projeto](#5-criterios-de-aceitação-mínimos-do-projeto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Considerações técnicas](#7-considerações-técnicas)
-* [8. Avaliação](#8-avaliação)
-* [9. Guias, dicas e leituras
-  complementares](#9-guias-dicas-e-leituras-complementares)
-* [10. Checklist](#10-checklist)
+* [8. Guias, dicas e leituras complementares](#8-guias-dicas-e-leituras-complementares)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -199,56 +196,9 @@ recomendadas (`"eslint:recommended"`)](https://eslint.org/docs/rules/).
 Nas regras/guias de estilo usaremos das recomandações padrão tanto para o
 `eslint` quanto `htmlhint`.
 
-## 8. Avaliação
-
-OBS: Esta seção inclui uma lista de habilidades que será levada em conta na hora
-de avaliar o projeto. O níveis _esperados_ são níveis _guias_ no desenho
-curricular, não são regras absolutas.
-
-Te aconselhamos revisar a [nossa
-rubrica](https://docs.google.com/spreadsheets/d/1hwyBoJWbA0MHGEMDLKqftIv64IhA1uKe2kmJhYpir4s/edit#gid=1789463812)
-para ver a descrição detalhada de cada _habilidade_ e _nível_. Te recomandamos
-também a se autoavaliar de acordo com a rubrica para acompanhar a sua evolução
-ao longo do Bootcamp.
-
-### Habilidades Interpessoais (Soft Skills)
-
-| Habilidade                                      | Nível esperado |
-|-------------------------------------------------|----------------|
-| Planejamento e administração do tempo           | 2              |
-| Autoaprendizado                                 | 2              |
-| Apresentações                                   | 2              |
-| Adaptabilidade                                  | 2              |
-| Solução de problemas                            | 2              |
-| Responsabilidade                                | 2              |
-| Dar e receber feedback                          | 2              |
-| Comunicação eficaz                              | 2              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidade                              | Nível esperado |
-|-----------------------------------------|----------------|
-| **Source Code Management (SCM)**                         |
-| Git                                     | 1              |
-| GitHub                                  | 2              |
-| **JavaScript**                                           |
-| Nomenclatura / semântica                | 2              |
-| Testes                                  | 2              |
-| **HTML/CSS**                                             |
-| Exatidão / Validação                    | 2              |
-| Semântica / Arquitetura de Informação   | 2              |
-| DRY (CSS)                               | 2              |
-| Responsive Web Design                   | 2              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidade      | Nível esperado |
-|-----------------|----------------|
-| User Centricity | 2              |
-
 ***
 
-## 9. Guias, dicas e leituras complementares
+## 8. Guias, dicas e leituras complementares
 
 ### Primeiros passos
 
@@ -321,7 +271,7 @@ Organização do trabalho:
 * [Guia em espanhol para a
   cifra](https://docs.google.com/presentation/d/e/2PACX-1vTQ7-8LZDHrT4Y6AOBN72Nkfz1eJAeseBHpcHX8BSq0aFCFoZmuMjluMeyFNgK9ISKxTz0H03yGfJiT/pub?start=false&loop=false&delayms=60000)
 
-## 10. Checklist
+## 9. Checklist
 
 Essa seção é para te ajudar a ter um controle do que você precisa completar.
 

--- a/projects/02-data-lovers/README.md
+++ b/projects/02-data-lovers/README.md
@@ -9,9 +9,8 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Consideraciones técnicas](#7-consideraciones-técnicas)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -355,61 +354,9 @@ asíncrona con [`fetch()`](https://developer.mozilla.org/es/docs/Web/API/Fetch_A
 Tendrás también que completar las pruebas unitarias de las funciones
 implementadas en el archivo `data.js`.
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 2              |
-| Autoaprendizaje                                 | 2              |
-| Presentaciones                                  | 2              |
-| Adaptabilidad                                   | 2              |
-| Solución de problemas                           | 2              |
-| Trabajo en equipo                               | 2              |
-| Responsabilidad                                 | 2              |
-| Dar y recibir feedback                          | 2              |
-| Comunicación eficaz                             | 2              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Arquitectura                            | 2              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 2              |
-| GitHub                                  | 2              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semántica                | 3              |
-| Estructuras de datos                    | 2              |
-| Tests                                   | 2              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 3              |
-| Semántica / Arquitectura de información | 2              |
-| DRY (CSS)                               | 3              |
-| Responsive Web Design                   | 2              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 3              |
-| Visual Design   | 2              |
-
 ***
 
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 
@@ -539,7 +486,7 @@ compañera:
 
 ***
 
-## 10. Checklist
+## 9. Checklist
 
 * [ ] Usa VanillaJS.
 * [ ] No hace uso de `this`.

--- a/projects/02-data-lovers/README.pt-BR.md
+++ b/projects/02-data-lovers/README.pt-BR.md
@@ -9,9 +9,8 @@
 * [5. Critérios mínimos de aceitação do projeto](#5-criterios-minimos-de-aceitacao-do-projeto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Considerações técnicas](#7-considerações-técnicas)
-* [8. Avaliação](#8-avaliacao)
-* [9. Pistas, dicas e leituras complementares](#9-pistas-dicas-e-leituras-complementares)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, dicas e leituras complementares](#8-pistas-dicas-e-leituras-complementares)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -349,54 +348,9 @@ para, opcionalmnente, ser carregado de forma assíncrona com
 Você também deverá fazer os teste unitários das funções implementadas no
 arquivo `data.js`.
 
-## 8. Avaliação
-
-NOTA: esta seção inclui uma lista de habilidades que poderão ser levadas em
-conta na avaliação do projeto. Os níveis esperados são _sugestões_, assim
-como _guias_, porém não são regras absolutas.
-
-Aconselhamos que revise [nossa rubrica](https://docs.google.com/spreadsheets/d/1hwyBoJWbA0MHGEMDLKqftIv64IhA1uKe2kmJhYpir4s/edit#gid=1789463812)
-para ver a descrição detalhada de cada habilidade e nível. Recomendamos também
-que procure aplicar a rubrica a você mesma e/ou seus projetos ao longo do
-bootcamp para ir acompanhando sua evolução.
-
-### Habilidades Interpessoais (Soft Skills)
-
-| Habilidade                                      | Nível esperado |
-|-------------------------------------------------|----------------|
-| Planejamento e administração do tempo           | 2              |
-| Autoaprendizado                                 | 2              |
-| Apresentações                                   | 2              |
-| Adaptabilidade                                  | 2              |
-| Solução de problemas                            | 2              |
-| Trabalho em equipe                              | 2              |
-| Responsabilidade                                | 2              |
-| Dar e receber feedback                          | 2              |
-| Comunicação eficaz                              | 2              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidade                              | Nível esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Arquitetura                             | 2              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 2              |
-| GitHub                                  | 2              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semântica                | 3              |
-| Estruturas de dados                     | 2              |
-| Testes                                  | 2              |
-| **HTML/CSS**                                             |
-| Exatidão / Validação                    | 3              |
-| Semântica / Arquitetura de Informação   | 2              |
-| DRY (CSS)                               | 3              |
-| Responsive Web Design                   | 2              |
-
 ***
 
-## 9. Pistas, dicas e leituras complementares
+## 8. Pistas, dicas e leituras complementares
 
 ### Primeiros passos
 
@@ -526,7 +480,7 @@ compañera:
 
 ***
 
-## 10. Checklist
+## 9. Checklist
 
 * [ ] Usar VanillaJS.
 * [ ] Não utilizar `this`.

--- a/projects/03-small-businesses/README.md
+++ b/projects/03-small-businesses/README.md
@@ -8,10 +8,9 @@
 * [4. Consideraciones generales](#4-consideraciones-generales)
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Consideraciones técnicas](#6-consideraciones-técnicas)
-* [7. Evaluación](#7-evaluación)
-* [8. Entrega](#8-entrega)
-* [9. Otras consideraciones](#9-otras-consideraciones)
-* [10. Hacker edition](#10-hacker-edition)
+* [7. Entrega](#7-entrega)
+* [8. Otras consideraciones](#8-otras-consideraciones)
+* [9. Hacker edition](#9-hacker-edition)
 
 ***
 
@@ -219,33 +218,7 @@ El coach o jedi master te dará el ok para que puedas empezar.
 |Prototipado de contenido| Prototipado y testeo del contenido del producto. | 30 |
 |Prototipado de alta fidelidad| Elaboración de prototipo en base a las pantallas diseñadas. | 80 |
 
-## 7. Evaluación
-
-Te aconsejamos revisar [la rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Esta es
-una lista de todas las habilidades involucradas en este proyecto y que
-evaluaremos cuando lo  completes:
-
-### Habilidades Técnicas (UX)
-
-| Habilidad                      | Nivel esperado |
-|--------------------------------|----------------|
-| **Research**                                    |
-| User centricity                | 3              |
-| Entrevistas                    | 2              |
-| Testing                        | 2              |
-| Planeamiento y ejecución       | 2              |
-| Síntesis de resultados         | 2              |
-| **Interaction design**                          |
-| Diseño de interacción          | 2              |
-| Arquitectura de la información | 2              |
-| Prototyping                    | 2              |
-| **Visual design**                               |
-| Visual Design                  | 3              |
-| **Business mindset**                            |
-| Business mindset               | 2              |
-
-## 8. Entrega
+## 7. Entrega
 
 El proyecto será entregado en un repositorio de GitHub. En él deberás agregar
 lo siguiente:
@@ -279,7 +252,7 @@ agregar los documentos complementarios que sustenten tu proceso:
 * Mapa de sitio
 * Etc.
 
-## 9. Otras consideraciones
+## 8. Otras consideraciones
 
 ### 1) Planeamiento y presupuesto
 
@@ -311,7 +284,7 @@ herramienta adicional como Marvel o Invision. Recuerda que el diseño que
 trabajes debe seguir los fundamentos de visual design, como: contraste,
 alineación, jerarquía, entre otros.
 
-## 10. Hacker edition
+## 9. Hacker edition
 
 * En lugar de usar Github para documentar tu proceso de trabajo, documéntalo en
   su propia web, puedes usar Wix, Instapage, Squarespace, Google Sites o crear

--- a/projects/03-social-network/README.md
+++ b/projects/03-social-network/README.md
@@ -9,8 +9,7 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Entrega](#7-entrega)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
 
 ***
 
@@ -259,64 +258,9 @@ El proyecto será _entregado_ subiendo tu código a GitHub (`commit`/`push`) y l
 interfaz será desplegada usando GitHub pages u otro servicio de hosting que
 puedas haber encontrado en el camino.
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 3              |
-| Autoaprendizaje                                 | 3              |
-| Presentaciones                                  | 3              |
-| Adaptabilidad                                   | 3              |
-| Solución de problemas                           | 3              |
-| Trabajo en equipo                               | 3              |
-| Responsabilidad                                 | 3              |
-| Dar y recibir feedback                          | 3              |
-| Comunicación eficaz                             | 3              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Lógica / Algoritmia                     | 2              |
-| Arquitectura                            | 2              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 3              |
-| GitHub                                  | 3              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semántica                | 3              |
-| Uso de funciones / modularidad          | 2              |
-| Estructuras de datos                    | 2              |
-| Tests                                   | 2              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 3              |
-| Estilo (linter html)                    | 3              |
-| Semántica / Arquitectura de información | 3              |
-| DRY (CSS)                               | 3              |
-| Responsive Web Design                   | 3              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 3              |
-| Visual Design   | 2              |
-
 ***
 
-## 9. Pistas, tips y Lecturas complementarias
+## 8. Pistas, tips y Lecturas complementarias
 
 ### Mobile first
 

--- a/projects/04-burger-queen/README.md
+++ b/projects/04-burger-queen/README.md
@@ -7,8 +7,7 @@
 * [3. Objetivos de aprendizaje](#3-objetivos-de-aprendizaje)
 * [4. Consideraciones generales](#4-consideraciones-generales)
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
-* [6. Evaluación](#6-evaluación)
-* [7. Pistas, tips y lecturas complementarias](#7-pistas-tips-y-lecturas-complementarias)
+* [6. Pistas, tips y lecturas complementarias](#6-pistas-tips-y-lecturas-complementarias)
 
 ***
 
@@ -253,64 +252,7 @@ rápidamente a los clientes que las hicieron.
 
 ***
 
-## 6. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 4              |
-| Autoaprendizaje                                 | 4              |
-| Presentaciones                                  | 4              |
-| Adaptabilidad                                   | 4              |
-| Solución de problemas                           | 4              |
-| Trabajo en equipo                               | 4              |
-| Responsabilidad                                 | 4              |
-| Dar y recibir feedback                          | 4              |
-| Comunicación eficaz                             | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Lógica / Algoritmia                     | 2              |
-| Arquitectura                            | 3              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 3              |
-| GitHub                                  | 3              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semántica                | 3              |
-| Uso de funciones / modularidad          | 4              |
-| Estructuras de datos                    | 3              |
-| Tests                                   | 3              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 3              |
-| Estilo (linter html)                    | 3              |
-| Semántica / Arquitectura de información | 4              |
-| DRY (CSS)                               | 4              |
-| Responsive Web Design                   | 4              |
-
-### Habilidades Técnicas (UX)
-
-| Habilidad       | Nivel esperado |
-|-----------------|----------------|
-| User Centricity | 4              |
-| Visual Design   | 2              |
-
-***
-
-## 7. Pistas, tips y lecturas complementarias
+## 6. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 

--- a/projects/04-md-links/README.md
+++ b/projects/04-md-links/README.md
@@ -9,9 +9,8 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Entregables](#6-entregables)
 * [7. Hacker edition](#7-hacker-edition)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -280,48 +279,9 @@ profundizar y/o ejercitar más sobre los objetivos de aprendizaje del proyecto.
 * Puedes agregar más estadísticas.
 * Integración continua con Travis o Circle CI.
 
-## 8. Evaluación
+***
 
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 4              |
-| Autoaprendizaje                                 | 4              |
-| Presentaciones                                  | 4              |
-| Adaptabilidad                                   | 4              |
-| Solución de problemas                           | 4              |
-| Responsabilidad                                 | 4              |
-| Dar y recibir feedback                          | 4              |
-| Comunicación eficaz                             | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                       | Nivel esperado |
-| --------------------------------|----------------|
-| **Computer Science (CS)**                        |
-| Lógica / Algoritmia             | 2              |
-| Arquitectura                    | 3              |
-| **Source Code Management (SCM)**                 |
-| Git                             | 3              |
-| GitHub                          | 3              |
-| **JavaScript**                                   |
-| Estilo (linter js)              | 3              |
-| Nomenclatura / semántica        | 3              |
-| Uso de funciones / modularidad  | 4              |
-| Estructuras de datos            | 3              |
-| Tests                           | 3              |
-
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 ### FAQs
 
@@ -393,7 +353,7 @@ si tienes dudas existenciales con respecto a estas decisiones. No existe una
 * [Path](https://nodejs.org/api/path.html)
 * [Linea de comando CLI](https://medium.com/netscape/a-guide-to-create-a-nodejs-command-line-package-c2166ad0452e)
 
-## 10. Checklist
+## 9. Checklist
 
 ### General
 

--- a/projects/04-md-links/README.pt-BR.md
+++ b/projects/04-md-links/README.pt-BR.md
@@ -6,14 +6,11 @@
 * [2. Resumo do projeto](#2-resumo-do-projeto)
 * [3. Objetivos de aprendizagem](#3-objetivos-de-aprendizagem)
 * [4. Considerações gerais](#4-considerações-gerais)
-* [5. Critérios de aceitação mínimos do
-  projeto](#5-criterios-de-aceitação-mínimos-do-projeto)
+* [5. Critérios de aceitação mínimos do projeto](#5-criterios-de-aceitação-mínimos-do-projeto)
 * [6. Entregáveis](#6-entregáveis)
 * [7. Hacker edition](#7-hacker-edition)
-* [8. Avaliação](#8-avaliação)
-* [9. Guias, dicas e leituras
-  complementares](#9-guias-dicas-e-leituras-complementares)
-* [10. Checklist](#10-checklist)
+* [8. Guias, dicas e leituras complementares](#8-guias-dicas-e-leituras-complementares)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -282,49 +279,9 @@ aprendizagem deste projeto.
 * Poder agregar mais estatísticas.
 * Integração contínua com Travis ou Circle CI.
 
-## 8. Avaliação
+***
 
-NOTA: Esta seção inclui uma lista de habilidades que podem ser levadas em conta
-na hora de avaliar o projeto. Os níveis esperados são _sugestões_ e _guias_ para
-o desenho curricular, não são regras absolutas.
-
-Te aconselhamos revisar [nossa
-rubrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ler a descrição mais detalhada de cada _habilidade_ e cada _nível_. Te
-recomendamos também se auto aplicar a rubrica ao longo do Bootcamp para ir vendo
-a sua evolução.
-
-### Habilidades Socioemocionais (Soft Skills)
-
-| Habilidade                                      | Nível esperado |
-|-------------------------------------------------|----------------|
-| Planejamento e administração do tempo           | 4              |
-| Autoaprendizado                                 | 4              |
-| Apresentações                                   | 4              |
-| Adaptabilidade                                  | 4              |
-| Solução de problemas                            | 4              |
-| Responsabilidade                                | 4              |
-| Dar e receber feedback                          | 4              |
-| Comunicação eficaz                              | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidade                              | Nível esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Lógica / Algoritmos                     | 2              |
-| Arquitetura                             | 3              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 3              |
-| GitHub                                  | 3              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semântica                | 3              |
-| Uso de funções / modularidade           | 4              |
-| Estrutura de dados                      | 3              |
-| Testes                                  | 3              |
-
-## 9. Guias, dicas e leituras complementares
+## 8. Guias, dicas e leituras complementares
 
 ### FAQs
 
@@ -407,7 +364,7 @@ destas decisões. Não existe uma única maneira certa :wink:
 * [Criando sua CLI com
   Node.js](https://medium.com/henriquekuwai/criando-sua-cli-com-node-js-d6dee7d03110)
 
-## 10. Checklist
+## 9. Checklist
 
 ### General
 

--- a/projects/04-redesign-and-data/README.md
+++ b/projects/04-redesign-and-data/README.md
@@ -9,7 +9,6 @@
 * [5. Entrega](#5-entrega)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Otras consideraciones](#7-otras-consideraciones)
-* [8. Evaluación](#8-evaluación)
 
 ***
 
@@ -181,28 +180,3 @@ ya que para el testing tendrás que usar una herramienta llamada
 
 Recuerda que el diseño que trabajes debe seguir los fundamentos de diseño visual
 como: contraste, alineación, jerarquía, entre otros.
-
-## 8. Evaluación
-
-Recuerda revisar la rúbrica para ver la descripción detallada de cada habilidad
-y cada nivel. A continuación presentamos los niveles esperados de cada habilidad
-que deberías alcanzar al finalizar este proyecto:
-
-### Habilidades Técnicas (UX)
-
-| Habilidad                      | Nivel esperado |
-|--------------------------------|----------------|
-| **Research**                                    |
-| User centricity                | 4              |
-| Entrevistas                    | 3              |
-| Testing                        | 3              |
-| Planeamiento y ejecución       | 3              |
-| Síntesis de resultados         | 3              |
-| **Interaction design**                          |
-| Diseño de interacción          | 3              |
-| Arquitectura de la información | 3              |
-| Prototyping                    | 3              |
-| **Visual design**                               |
-| Visual Design                  | 3              |
-| **Business mindset**                            |
-| Business mindset               | 3              |

--- a/projects/04-social-network-frameworks/README.md
+++ b/projects/04-social-network-frameworks/README.md
@@ -9,9 +9,8 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Entrega](#7-entrega)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -93,70 +92,9 @@ El proyecto será _entregado_ subiendo tu código a GitHub (`commit`/`push`) y l
 interfaz será desplegada usando GitHub pages u otro servicio de hosting que
 puedas haber encontrado en el camino.
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-Para este proyecto esperamos que ya hayas consolidado el nivel 4 en todas tus
-habilidades blandas pero te invitamos que las lleves al siguiente nivel
-alcanzando el nivel 5 en todas ellas. Particularmente, entrena tu habilidad de
-autoaprendizaje, planificación y organización, y dar y recibir feedback.
-
-Recuerda la importancia de organizar, dividir y planificar tu trabajo.
-Particularmente lo que se refiere a probar/experimentar lo nuevo de manera
-aislada y no necesariamente en el mismo código que ya tienes implementado.
-Muchas cosas pueden interferir en lo que estás intentando hacer y puede parecer
-que no está bien lo que intentas cuando no es así. Revisa las diapos 15 y 16 de
-la [guia general para organizar, dividir y planificar tu ttrabajo](https://docs.google.com/presentation/d/e/2PACX-1vQhx9D36NjpH-Daea-ITPUDUzNL8ZiNAprq_7b5PSUrfutk45tEtaOLz2lmd8f54_5jX1hypDM8f8SM/pub?start=false&loop=false&delayms=60000).
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 4              |
-| Autoaprendizaje                                 | 4              |
-| Presentaciones                                  | 4              |
-| Adaptabilidad                                   | 4              |
-| Solución de problemas                           | 4              |
-| Trabajo en equipo                               | 4              |
-| Responsabilidad                                 | 4              |
-| Dar y recibir feedback                          | 4              |
-| Comunicación eficaz                             | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                               | Nivel esperado |
-|-----------------------------------------|----------------|
-| **Computer Science (CS)**                                |
-| Lógica / Algoritmia                     | 2              |
-| Arquitectura                            | 3              |
-| Patrones/Paradigmas                     | 2              |
-| **Source Code Management (SCM)**                         |
-| Git                                     | 3              |
-| GitHub                                  | 3              |
-| **JavaScript**                                           |
-| Estilo (linter js)                      | 3              |
-| Nomenclatura / semántica                | 3              |
-| Uso de funciones / modularidad          | 4              |
-| Estructuras de datos                    | 3              |
-| Tests                                   | 3              |
-| **HTML/CSS**                                             |
-| Correctitud / Validación                | 3              |
-| Estilo (linter html)                    | 3              |
-| Semántica / Arquitectura de información | 4              |
-| DRY (CSS)                               | 4              |
-| Responsive Web Design                   | 4              |
-
 ***
 
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 Antes de elegir un framework, te recomendamos leer los siguientes artículos:
 
@@ -200,7 +138,7 @@ se usan muchas veces en conjunción con Redux como manejador de _estado_.
 
 * [Redux - docs oficiales](https://redux.js.org/)
 
-## 10. Checklist
+## 9. Checklist
 
 ### General
 

--- a/projects/05-bq-node/README.md
+++ b/projects/05-bq-node/README.md
@@ -17,9 +17,8 @@ en releases futuros.
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Entrega](#7-entrega)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -261,50 +260,9 @@ El proyecto será _entregado_ subiendo tu código a GitHub (`commit`/`push`) y l
 aplicación será desplegada en [zeit.co](https://zeit.co/) y
 [cloud.mongodb.com](https://cloud.mongodb.com/), o servicios equivalentes.
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 4              |
-| Autoaprendizaje                                 | 4              |
-| Presentaciones                                  | 4              |
-| Adaptabilidad                                   | 4              |
-| Solución de problemas                           | 4              |
-| Responsabilidad                                 | 4              |
-| Dar y recibir feedback                          | 4              |
-| Comunicación eficaz                             | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                      | Nivel esperado |
-| -------------------------------|----------------|
-| **Computer Science (CS)**                       |
-| Lógica / Algoritmia            | 2              |
-| Arquitectura                   | 3              |
-| **Source Code Management (SCM)**                |
-| Git                            | 3              |
-| GitHub                         | 3              |
-| **JavaScript**                                  |
-| Estilo (linter js)             | 3              |
-| Nomenclatura / semántica       | 3              |
-| Uso de funciones / modularidad | 4              |
-| Estructuras de datos           | 3              |
-| Tests                          | 3              |
-
 ***
 
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 
@@ -376,7 +334,7 @@ puedes ejecutarlo con `npm run deploy`.
 
 ***
 
-## 10. Checklist
+## 9. Checklist
 
 ### HTTP API
 

--- a/projects/05-tic-tac-toe-rn/README.md
+++ b/projects/05-tic-tac-toe-rn/README.md
@@ -9,9 +9,8 @@
 * [5. Criterios de aceptación mínimos del proyecto](#5-criterios-de-aceptación-mínimos-del-proyecto)
 * [6. Hacker edition](#6-hacker-edition)
 * [7. Entrega](#7-entrega)
-* [8. Evaluación](#8-evaluación)
-* [9. Pistas, tips y lecturas complementarias](#9-pistas-tips-y-lecturas-complementarias)
-* [10. Checklist](#10-checklist)
+* [8. Pistas, tips y lecturas complementarias](#8-pistas-tips-y-lecturas-complementarias)
+* [9. Checklist](#9-checklist)
 
 ***
 
@@ -100,50 +99,9 @@ Como entregables, al final del proyeto debes presentar:
 * Link a repositorio en GitHub con tu código fuente
 * Link a tu aplicación desplegada en tu perfil en el website de [Expo](https://expo.io/).
 
-## 8. Evaluación
-
-NOTA: Esta sección incluye una lista de habilidades que se podrán tener en
-cuenta a la hora de evaluar el proyecto. Los niveles esperados son _sugerencias_
-así como _guías_ en el diseño curricular, pero no reglas absolutas.
-
-Te aconsejamos revisar [nuestra rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Te
-recomendamos también que trates de aplicarte la rúbrica a tí misma y/o a los
-proyectos de tus compañeras a lo largo del Bootcamp para ir viendo tu evolución.
-
-### Habilidades Blandas (Soft Skills)
-
-| Habilidad                                       | Nivel esperado |
-|-------------------------------------------------|----------------|
-| Planificación, organización y manejo del tiempo | 4              |
-| Autoaprendizaje                                 | 4              |
-| Presentaciones                                  | 4              |
-| Adaptabilidad                                   | 4              |
-| Solución de problemas                           | 4              |
-| Responsabilidad                                 | 4              |
-| Dar y recibir feedback                          | 4              |
-| Comunicación eficaz                             | 4              |
-
-### Habilidades Técnicas (Front-end)
-
-| Habilidad                      | Nivel esperado |
-| -------------------------------|----------------|
-| **Computer Science (CS)**                       |
-| Lógica / Algoritmia            | 2              |
-| Arquitectura                   | 3              |
-| **Source Code Management (SCM)**                |
-| Git                            | 3              |
-| GitHub                         | 3              |
-| **JavaScript**                                  |
-| Estilo (linter js)             | 3              |
-| Nomenclatura / semántica       | 3              |
-| Uso de funciones / modularidad | 4              |
-| Estructuras de datos           | 3              |
-| Tests                          | 3              |
-
 ***
 
-## 9. Pistas, tips y lecturas complementarias
+## 8. Pistas, tips y lecturas complementarias
 
 ### Primeros pasos
 
@@ -310,7 +268,7 @@ expo publish
 
 ***
 
-## 10. Checklist
+## 9. Checklist
 
 ### UI
 

--- a/projects/05-ux-consultancy/README.md
+++ b/projects/05-ux-consultancy/README.md
@@ -3,7 +3,6 @@
 ## Índice
 
 * [1. Resumen del proyecto](#2-resumen-del-proyecto)
-* [2. Evaluación](#7-evaluación)
 
 ***
 
@@ -13,29 +12,3 @@ En este reto, las estudiantes trabajan en distintos casos reales propuestos
 por empresas de diversos rubros y tamaños. Anteriores retos han incluido
 empresas como Kmimos, Guvery, Globant, Sinenvolturas, Magical Startups,
 Laboratoria, entre otras.
-
-## 2. Evaluación
-
-Te aconsejamos revisar [la rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Esta es
-una lista de todas las habilidades involucradas en este proyecto y que
-evaluaremos cuando lo  completes:
-
-### Habilidades Técnicas (UX)
-
-| Habilidad                      | Nivel esperado |
-|--------------------------------|----------------|
-| **Research**                                    |
-| User centricity                | 4              |
-| Entrevistas                    | 4              |
-| Testing                        | 4              |
-| Planeamiento y ejecución       | 4              |
-| Síntesis de resultados         | 4              |
-| **Interaction design**                          |
-| Diseño de interacción          | 3              |
-| Arquitectura de la información | 3              |
-| Prototyping                    | 4              |
-| **Visual design**                               |
-| Visual Design                  | 3              |
-| **Business mindset**                            |
-| Business mindset               | 4              |

--- a/projects/06-service-design/README.md
+++ b/projects/06-service-design/README.md
@@ -3,7 +3,6 @@
 ## Índice
 
 * [1. Resumen del proyecto](#2-resumen-del-proyecto)
-* [2. Evaluación](#7-evaluación)
 
 ***
 
@@ -13,29 +12,3 @@ Con la ayuda de consultoras especializadas como Amable o Touchpoint, las
 estudiantes se sumergen en el mundo del service design. Entendiendo problemas
 de negocio desde una visión más holística y utilizando nuevas herramientas
 como el Service BluePrint.
-
-## 2. Evaluación
-
-Te aconsejamos revisar [la rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Esta es
-una lista de todas las habilidades involucradas en este proyecto y que
-evaluaremos cuando lo  completes:
-
-### Habilidades Técnicas (UX)
-
-| Habilidad                      | Nivel esperado |
-|--------------------------------|----------------|
-| **Research**                                    |
-| User centricity                | 5              |
-| Entrevistas                    | 4              |
-| Testing                        | 4              |
-| Planeamiento y ejecución       | 4              |
-| Síntesis de resultados         | 4              |
-| **Interaction design**                          |
-| Diseño de interacción          | 3              |
-| Arquitectura de la información | 3              |
-| Prototyping                    | 4              |
-| **Visual design**                               |
-| Visual Design                  | 3              |
-| **Business mindset**                            |
-| Business mindset               | 4              |

--- a/projects/06-visual-design/README.md
+++ b/projects/06-visual-design/README.md
@@ -5,7 +5,6 @@
 * [1. Preámbulo](#1-preámbulo)
 * [2. Resumen del proyecto](#2-resumen-del-proyecto)
 * [3. Entrega](#3-entrega)
-* [4. Evaluación](#4-evaluación)
 
 ***
 
@@ -94,26 +93,3 @@ agregar los documentos complementarios que sustenten tu proceso:
 * Flujo de usuario
 * Mapa de sitio
 * Etc.
-
-## 4. Evaluación
-
-Te aconsejamos revisar [la rúbrica](https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRktPN4ilZtkRN5tUb3DVhgeihwlzk63_-JI3moA-bXpKDbHDioAK2H3qbrwWNb0Ql4wX22Tgv7-PDv/pubhtml)
-para ver la descripción detallada de cada _habilidad_ y cada _nivel_. Esta es
-una lista de todas las habilidades involucradas en este proyecto y que
-evaluaremos cuando lo  completes:
-
-### Habilidades Técnicas (UX)
-
-| Habilidad                      | Nivel esperado |
-|--------------------------------|----------------|
-| **Research**                                    |
-| User centricity                | 4              |
-| Testing                        | 4              |
-| **Interaction design**                          |
-| Diseño de interacción          | 4              |
-| Arquitectura de la información | 4              |
-| Prototyping                    | 4              |
-| **Visual design**                               |
-| Visual Design                  | 4              |
-| **Business mindset**                            |
-| Business mindset               | 4              |


### PR DESCRIPTION
This change replaces the assessment (evaluación) section in individual
project readme's. These sections used to list a bunch of skills from the
already deprecated rubric (v3.x). These are being replaced by the
learning objetives (objetivos de aprendizaje) found elsewhere on the
readmes.

Instead if having assessment info in each readme, this PR proposes that
this info be shared by ALL projects and thus live outside of the project
readmes. As such, the project assessment info is being added to the main
repo readme (independent from individual projects).

Also note that the language has been tweaked a bit to make it more
generic and also to avoid abusing the word "evaluación".

Closes #881