### PR TITLE
Arregla conf de eslint en proyecto md-links

### DIFF
--- a/projects/04-md-links/.eslintrc
+++ b/projects/04-md-links/.eslintrc
@@ -1,8 +1,8 @@
 {
   "env": {
-    "browser": true
+    "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 8
   }
 }


### PR DESCRIPTION
* Cambia `env` de `browser` a `node` (esto estaba mal :scream:)
* Aumenta versión del parser de ES a 8.