### PR TITLE
Agrega referencia a listado de objetivos de aprendizaje

### DIFF
--- a/projects/02-emergency-room/README.md
+++ b/projects/02-emergency-room/README.md
@@ -49,7 +49,7 @@ en Vanilla JavaScript o algún _framework_  o biblioteca (librería) de tu elecc
 
 ### Generales
 
-1. Aplicar y profundizar todo lo que ya aprendiste.
+1. [Aplicar y profundizar todo lo que ya aprendiste](../learning-objectives.md).
 2. Pensar en las necesidades de las personas para crear tus "Historias de Usuario".
 3. Escribir y trabajar con historias de usuario, sus definiciones de terminado
 (_definition of done_) y criterios de aceptación como herramienta central de la

--- a/projects/02-movie-challenge/README.md
+++ b/projects/02-movie-challenge/README.md
@@ -59,8 +59,8 @@ personas en el equipo, permita terminar el proyecto en 2 semanas.
 
 ## 4. Objetivos de aprendizaje
 
+- [Poner en práctica todo lo aprendido hasta ahora](../learning-objectives.md).
 - Diseñar y testear un producto antes de desarrollarlo.
-- Poner en práctica todo lo aprendido hasta ahora.
 - Obtener datos desde un servicio externo como OMDB usando _Fetch_.
 - Entender la idea de aleatoriedad aplicada a algoritmos.
 

--- a/projects/03-visitors/README.md
+++ b/projects/03-visitors/README.md
@@ -53,7 +53,7 @@ personas en el equipo, te permita terminar el proyecto en 3 semanas.
 
 ## 4. Objetivos de aprendizaje
 
-- Poner en práctica todo lo aprendido hasta ahora.
+- [Poner en práctica todo lo aprendido hasta ahora](../learning-objectives.md).
 - Diseñar y _testear_ un producto antes de desarrollarlo.
 - Usar Historias de Usuarix para dividir, comunicar y priorizar las tareas a
 realizar.

--- a/projects/04-news-alerts/README.md
+++ b/projects/04-news-alerts/README.md
@@ -78,7 +78,7 @@ personas en el equipo, te permita terminar el proyecto en 3 semanas.
 
 ## 4. Objetivos de aprendizaje
 
-- Poner en práctica todo lo aprendido hasta ahora.
+- [Poner en práctica todo lo aprendido hasta ahora](../learning-objectives.md).
 - Diseñar y _testear_ un producto antes de desarrollarlo.
 - Obtener datos de una fuente viva como lo es un sitio web usando alguna técnica
 de [_web scrapping_](https://es.wikipedia.org/wiki/Web_scraping).

--- a/projects/06-open-project/README.md
+++ b/projects/06-open-project/README.md
@@ -47,7 +47,7 @@ en que te tome 2 a 3 semanas como máximo.
 Por la naturaleza de este proyecto, los objetivos los tendrás que definir tú
 misma. Algunas sugerencias:
 
-- Reforzar algunas habilidades técnicas adquiridas durante el BC.
+- [Reforzar algunas habilidades técnicas adquiridas durante el BC](../learning-objectives.md).
 - Profundizar en alguna(s) de las habilidades adquiridas para ser mucho más
 competente en ella(s), piensa en la idea de las [habilidades en forma de “T”](https://www.google.com/search?q=habilidades+en+forma+de+t).
 


### PR DESCRIPTION
Ahora estos proyectos apuntan a un listado que puede cambiar en el tiempo,
esta estrategia me pareció más consciente al tiempo que escribir todos los
objetivos de aprendizaje por cada proyecto.