### PR TITLE
Fix cipher decode test function

### DIFF
--- a/projects/01-cipher/test/cipher.spec.js
+++ b/projects/01-cipher/test/cipher.spec.js
@@ -65,10 +65,10 @@ describe('cipher', () => {
     });
 
     it('should throw TypeError when invoked with wrong argument types', () => {
-      expect(() => cipher.encode()).toThrow(TypeError);
-      expect(() => cipher.encode(0)).toThrow(TypeError);
-      expect(() => cipher.encode(null, [])).toThrow(TypeError);
-      expect(() => cipher.encode(0, 0)).toThrow(TypeError);
+      expect(() => cipher.decode()).toThrow(TypeError);
+      expect(() => cipher.decode(0)).toThrow(TypeError);
+      expect(() => cipher.decode(null, [])).toThrow(TypeError);
+      expect(() => cipher.decode(0, 0)).toThrow(TypeError);
     });
 
     it('should return "ABCDEFGHIJKLMNOPQRSTUVWXYZ" for "HIJKLMNOPQRSTUVWXYZABCDEFG" with offset 33', () => {


### PR DESCRIPTION
`cipher.decode` function test was actually calling the `cipher.encode`. This PR fixes it.