### PR TITLE
Removes obsolete learning objective 'Construir tu aplicación respetando el diseño realizado'

### DIFF
--- a/projects/00-trivia/README.md
+++ b/projects/00-trivia/README.md
@@ -52,7 +52,6 @@ Piensa en eso al decidir tu estrategia de trabajo individual y de equipo.
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 
 ### DOM
 

--- a/projects/00-trivia/README.pt-BR.md
+++ b/projects/00-trivia/README.pt-BR.md
@@ -53,7 +53,6 @@ equipe.
 
 * [ ] [Uso de HTML semântico.](https://developer.mozilla.org/pt-BR/docs/Glossario/Semantica#Sem%C3%A2ntica_em_HTML)
 * [ ] Uso de seletores de CSS.
-* [ ] Construa sua aplicação respeitando o design feito (layout).
 
 ### DOM
 

--- a/projects/01-card-validation/README.md
+++ b/projects/01-card-validation/README.md
@@ -48,7 +48,6 @@ como tecnologías.
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 
 ### DOM
 

--- a/projects/01-cipher/README.md
+++ b/projects/01-cipher/README.md
@@ -68,7 +68,6 @@ como tecnologías.
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 
 ### DOM
 

--- a/projects/02-data-lovers/README.md
+++ b/projects/02-data-lovers/README.md
@@ -91,7 +91,6 @@ usuario necesita.
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 ### DOM y Web APIs

--- a/projects/02-data-lovers/README.pt-BR.md
+++ b/projects/02-data-lovers/README.pt-BR.md
@@ -92,7 +92,6 @@ Em outras palavras, você aprenderá a:
 
 * [ ] [Uso de HTML semântico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de seletores de CSS.
-* [ ] Construir sua aplicação respeitando o desenho realizado (protótipo).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 ### DOM y Web APIs

--- a/projects/02-memory-match/README.md
+++ b/projects/02-memory-match/README.md
@@ -43,7 +43,6 @@ interfaz web basada en data e interacción con la usuaria.
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 ### DOM y Web APIs

--- a/projects/03-social-network/README.md
+++ b/projects/03-social-network/README.md
@@ -46,7 +46,6 @@ en la que podamos **leer y escribir datos.**
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 * [ ] [Uso de CSS Grid Layout](https://css-tricks.com/snippets/css/complete-guide-grid/)
 

--- a/projects/03-social-network/README.pt-BR.md
+++ b/projects/03-social-network/README.pt-BR.md
@@ -52,7 +52,6 @@ qual seja possível **ler e escrever dados.**
 * [ ] [HTML
   semântico](https://developer.mozilla.org/pt-BR/docs/Glossario/Semantica)
 * [ ] [CSS `flexbox`](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
-* [ ] Construir sua aplicação respeitando o protótipo.
 
 ### DOM e Web APIs
 

--- a/projects/04-burger-queen-api-client/README.md
+++ b/projects/04-burger-queen-api-client/README.md
@@ -111,7 +111,6 @@ a un _pedido_, la interfaz debe actualizar la lista del pedido y el total).
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 * [ ] [Uso de Media Queries.](https://developer.mozilla.org/es/docs/CSS/Media_queries)
 

--- a/projects/04-burger-queen/README.md
+++ b/projects/04-burger-queen/README.md
@@ -109,7 +109,6 @@ A continuación puedes ver los objetivos de aprendizaje de este proyecto:
 
 * [ ] [Uso de HTML semántico.](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML)
 * [ ] Uso de selectores de CSS.
-* [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 * [ ] [Uso de flexbox en CSS.](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 * [ ] [Uso de Media Queries.](https://developer.mozilla.org/es/docs/CSS/Media_queries)
 

--- a/projects/learning-objectives.md
+++ b/projects/learning-objectives.md
@@ -11,7 +11,6 @@
 
 - [ ] Uso de HTML semántico.
 - [ ] Uso de selectores de CSS.
-- [ ] Construir tu aplicación respetando el diseño realizado (maquetación).
 - [ ] Uso de flexbox en CSS.
 - [ ] Uso de Media Queries.
 - [ ] Sass


### PR DESCRIPTION
Desde hace ya un tiempo se ha venido conversando la idea de quitar este objetivo de aprendizaje (_Construir tu aplicación respetando el diseño realizado_), ya que no consideramos que sea un objetivo de aprendizaje como tal, si no más bien un criterio de aceptación del proyecto en cuestión. Este cambio afecta a los proyectos `trivia`, `card-validation`, `cipher`, `data-lovers`, `memory-match`, `social-network`, `burger-queen`, `burger-queen-api-client`.