### PR TITLE
Project/emergency room tweaks

### DIFF
--- a/projects/02-emergency-room/.eslintrc
+++ b/projects/02-emergency-room/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "browser": true
+    "browser": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/projects/02-emergency-room/package.json
+++ b/projects/02-emergency-room/package.json
@@ -7,7 +7,7 @@
     "htmlhint": "htmlhint src/*.html test/*.html",
     "eslint": "eslint --ext .js src/ test/",
     "pretest": "npm run eslint && npm run htmlhint",
-    "test": "jest --verbose --coverage",
+    "test": "jest --coverage",
     "open-coverage-report": "opener ./coverage/lcov-report/index.html",
     "start": "serve src/",
     "deploy": "gh-pages -d src"


### PR DESCRIPTION
* Agrega jest a config de eslint. Esto evita que reviente el linter al correr las pruebas del boilerplate.
*  Quita flag `--verbose` de tests (no hace nada :shrug:)