### PR TITLE
Quita requerimiento de evitar pseudo-variable this

### DIFF
--- a/projects/00-trivia/README.md
+++ b/projects/00-trivia/README.md
@@ -137,8 +137,6 @@ La lógica del proyecto debe estar implementada completamente en JS, HTML y CSS
 En este proyecto NO está permitido usar librerías o frameworks,
 solo [vanilla JavaScript](https://medium.com/laboratoria-how-to/vanillajs-vs-jquery-31e623bbd46e).
 
-No se debe utilizar la _pseudo-variable_ `this`.
-
 ### `src/index.html`
 
 Acá va la página que se mostrará al usuario, también nos sirve para indicar

--- a/projects/00-trivia/README.pt-BR.md
+++ b/projects/00-trivia/README.pt-BR.md
@@ -139,8 +139,6 @@ A lógica do projeto deve estar implementada completamente em JS, HTML e CSS.
 Neste projeto não é permitido usar bibliotecas ou frameworks, somente [vanilla
 JavaScript](https://medium.com/laboratoria-how-to/vanillajs-vs-jquery-31e623bbd46e).
 
-Não deve ser usada a _pseudo-variável_ `this`.
-
 ### `src/index.html`
 
 Aqui vai a página que será mostrada para o usuário. Também nos serve para

--- a/projects/01-card-validation/README.md
+++ b/projects/01-card-validation/README.md
@@ -176,9 +176,8 @@ propias reglas, por eso NO está permitido el uso de frameworks de CSS
 #### Funcionalmente (JavaScript - pruebas unitarias)
 
 * La lógica del proyecto debe estar implementada completamente en JavaScript.
-* En este proyecto NO está permitido usar librerías o frameworks, sólo JavaScript
-puro también conocido como Vanilla JavaScript.
-* No se debe utilizar la _pseudo-variable_ `this`.
+* En este proyecto NO está permitido usar librerías o frameworks, solo
+  JavaScript puro también conocido como Vanilla JavaScript.
 
 Vas a tener 2 archivos JavaScript separando responsabilidades, a continuación
 indicamos qué harás en cada archivo:

--- a/projects/01-card-validation/README.pt-BR.md
+++ b/projects/01-card-validation/README.pt-BR.md
@@ -170,7 +170,6 @@ NÃO é permitido.
 * A lógica do projeto deve ser totalmente implementada em JavaScript.
 * NÃO é permitido usar bibliotecas ou frameworks neste projeto, apenas
   JavaScript puro, também conhecido como JavaScript Vanilla.
-* A _pseudo variável_ `this` não deve ser utilizada.
 
 Você terá 2 arquivos JavaScript que separam responsabilidades, eis o que você
 fará em cada arquivo:

--- a/projects/01-cipher/README.md
+++ b/projects/01-cipher/README.md
@@ -180,8 +180,6 @@ La lógica del proyecto debe estar implementada completamente en JavaScript. En
 este proyecto NO está permitido usar librerías o frameworks, solo JavaScript puro
 también conocido como Vanilla JavaScript.
 
-No se debe utilizar la _pseudo-variable_ `this`.
-
 Los tests unitarios deben cubrir un mínimo del 70% de _statements_, _functions_
 y _lines_, y un mínimo del 50% de _branches_. El _boilerplate_ ya contiene el
 setup y configuración necesaria para ejecutar los tests (pruebas) así como _code
@@ -328,7 +326,6 @@ Esta sección está para ayudarte a llevar un control de lo que vas completando.
 * [ ] `README.md` explica claramente cómo el producto soluciona los
   problemas/necesidades de los usuarios.
 * [ ] Usa VanillaJS.
-* [ ] No utiliza `this`.
 * [ ] Implementa `cipher.encode`.
 * [ ] Implementa `cipher.decode`.
 * [ ] Pasa linter con configuración provista.

--- a/projects/02-data-lovers/README.md
+++ b/projects/02-data-lovers/README.md
@@ -246,8 +246,6 @@ frameworks, solo [vanilla JavaScript](https://medium.com/laboratoria-how-to/vani
 con la excepción de librerías para hacer gráficas (charts); ver
 [_Parte opcional_](#6-hacker-edition) más arriba.
 
-No se debe utilizar la _pseudo-variable_ `this`.
-
 El _boilerplate_ contiene una estructura de archivos como punto de partida así
 como toda la configuración de dependencias:
 
@@ -455,7 +453,6 @@ Cuando ya estés lista para codear, te sugerimos empezar de esta manera:
 ## 9. Checklist
 
 * [ ] Usa VanillaJS.
-* [ ] No hace uso de `this`.
 * [ ] Pasa linter (`npm run pretest`)
 * [ ] Pasa tests (`npm test`)
 * [ ] Pruebas unitarias cubren un mínimo del 70% de statements, functions y

--- a/projects/02-data-lovers/README.pt-BR.md
+++ b/projects/02-data-lovers/README.pt-BR.md
@@ -249,8 +249,6 @@ JavaScript](https://medium.com/laboratoria-how-to/vanillajs-vs-jquery-31e623bbd4
 com exceção das bibliotecas para gráficos (ver [_Parte
 opcional_](#6-hacker-edition) acima).
 
-Não se deve utilizar a _pseudo-variável_ `this`.
-
 O _boilerplate_ contém uma estrutura de arquivos como ponto de partida, assim
 como toda a configuração de dependências:
 
@@ -469,7 +467,6 @@ Quando estiver pronta para codar, sugerimos começar desta forma:
 ## 9. Checklist
 
 * [ ] Usar VanillaJS.
-* [ ] Não utilizar `this`.
 * [ ] Passa pelo linter (`npm run pretest`)
 * [ ] Passa pelos testes (`npm test`)
 * [ ] Testes unitários cobrem um mínimo de 70% de statements, functions, lines e

--- a/projects/02-memory-match/README.md
+++ b/projects/02-memory-match/README.md
@@ -196,8 +196,6 @@ La lógica del proyecto debe estar implementada completamente en JavaScript,
 HTML y CSS. En este proyecto NO está permitido usar librerías o frameworks, solo
 [vanilla JavaScript](https://medium.com/laboratoria-how-to/vanillajs-vs-jquery-31e623bbd46e).
 
-No se debe utilizar la _pseudo-variable_ `this`.
-
 Para iniciar un nuevo juego, siempre tendremos que _barajar_ las cartas antes de
 pintarlas en la pantalla. Para eso, te invitamos a que explores algoritmos
 existentes para este tipo de operación (llamada _shuffle_ en inglés), como por
@@ -366,7 +364,6 @@ Cuando ya estés lista para codear, te sugerimos empezar de esta manera:
 ## 9. Checklist
 
 * [ ] Usa VanillaJS.
-* [ ] No hace uso de `this`.
 * [ ] Pasa linter (`npm run pretest`)
 * [ ] Pasa tests (`npm test`)
 * [ ] Pruebas unitarias cubren un mínimo del 70% de statements, functions y


### PR DESCRIPTION
Siguiendo con la conversación iniciada por @AdrianaHY en Slack (canal `#equipo-bootcamp-reg`), este PR propone quitar el requerimiento de "_no usar la pseudo-variable `this`_" en los proyectos. En principio esta conversación surgió con respecto al proyecto `trivia` usado durante el proceso de _preBootcamp_ (aka _pre admisión_), ya que parece que causa bastantes dudas innecesarias sobre `this` y toda la complejidad y sutilezas que conlleva en JavaScript.

Como contexto, es algo que hemos heredado de hace años, cuando todavía la mayoría de ejemplos que uno encontraba en internet hacían uso y abuso the `this`, que, antes de la funciones flechas y el ámbito de bloque, eran trampas en las que podíamos caer muy fácilmente.

Varias coaches se han mostrado a favor del cambio para evitar confusión innecesaria. Yo feliz de quitarlo del proyecto de `trivia`. Ahora, me queda la duda de si quitar también el requerimiento de el resto de proyectos donde aparece, que además son los primeros proyectos. Se agradece su feedback.

Este _requerimiento_ aparece en varios proyectos: [`trivia`](https://github.com/Laboratoria/bootcamp/tree/main/projects/00-trivia), [`card-validation`](https://github.com/Laboratoria/bootcamp/tree/main/projects/01-card-validation), [`cipher`](https://github.com/Laboratoria/bootcamp/tree/main/projects/01-cipher), [`data-lovers`](https://github.com/Laboratoria/bootcamp/tree/main/projects/02-data-lovers) y [`memory-match`](https://github.com/Laboratoria/bootcamp/tree/main/projects/02-memory-match).

cc/ @Laboratoria/coaches