### PR TITLE
Agrega mensaje de ayuda para uso de create-cohort-project

### DIFF
--- a/scripts/create-cohort-project.js
+++ b/scripts/create-cohort-project.js
@@ -251,16 +251,47 @@ const main = async (args, opts) => {
   `);
 };
 
+/* Arguments From Shell \m/ */
+const handleArgs = (argumentsFromShell) => {
+  return minimist(argumentsFromShell.slice(2));
+}
 
-if (module === require.main) {
-  const { _: args, ...opts } = minimist(process.argv.slice(2));
-  // Trim trailing slashes from args...
-  const trimmedArgs = args.map(arg => (
+const trimSlashes = (args) => {
+  return args.map(arg => (
     arg[arg.length - 1] === '/'
       ? arg.slice(0, -1)
       : arg
   ));
-  main(trimmedArgs, opts)
+}
+
+const printUsage = () => {
+  console.log(`create-cohort-project es un script para crear un nuevo proyecto
+del bootcamp, para un cohort en particular. Este es un mensaje
+de ayuda para que puedas usarlo.
+
+  Uso:
+    npm run create-cohort-project <RUTA_PROYECTO_ORIGEN> <RUTA_DESTINO> <PREFIJO_COHORT>
+
+  Ejemplo:
+    npm run create-cohort-project projects/04-md-links ./ LIM042	crea el proyecto Markdown Links en la ruta actual para LIM042
+    `);
+}
+
+const noOptionsOrHelp = (args) => {
+  return args.length === 0 || ['-h', '--help'].includes(args[0]);
+}
+
+if (module === require.main) {
+  const { _: args, ...opts } = handleArgs(process.argv);
+
+  if (noOptionsOrHelp(args)) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const argsWithoutSlashes = trimSlashes(args);
+
+  main(argsWithoutSlashes, opts)
     .catch((err) => {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
Me interesó revisar este script porque no pude estar presente un día que @mfdebian y @ElizabethVegaM hicieron una demo a varias coaches de SCL de su uso. Para que sea más fácil comunicar cómo se ocupa agregué un mensaje de ayuda con los argumentos desde la shell y un ejemplo, de esta forma el onboarding es más rápido ❇️

Al principio me costó entender un poco así que aproveché de extraer algunas funciones para que sea más sencillo de ir manteniendo 👍🏼 

Gracias a @ElizabethVegaM por enviarme la grabación de la sesión 💯