### PR TITLE
chore(projects): Agrega opción `-s` a ejecución de `serve` y sube la versión a 13.0.2

### DIFF
--- a/projects/01-card-validation/package.json
+++ b/projects/01-card-validation/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run eslint && npm run htmlhint",
     "test": "jest --verbose --coverage",
     "open-coverage-report": "opener ./coverage/lcov-report/index.html",
-    "start": "serve ./src",
+    "start": "serve -s ./src",
     "deploy": "gh-pages -d src"
   },
   "dependencies": {
@@ -21,6 +21,6 @@
     "htmlhint": "^0.15.1",
     "jest": "^27.0.1",
     "opener": "^1.5.1",
-    "serve": "^12.0.0"
+    "serve": "^13.0.2"
   }
 }

--- a/projects/01-cipher/package.json
+++ b/projects/01-cipher/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run eslint && npm run htmlhint",
     "test": "jest --verbose --coverage",
     "open-coverage-report": "opener ./coverage/lcov-report/index.html",
-    "start": "serve ./src",
+    "start": "serve -s ./src",
     "deploy": "gh-pages -d src"
   },
   "dependencies": {
@@ -21,6 +21,6 @@
     "htmlhint": "^0.15.1",
     "jest": "^27.0.1",
     "opener": "^1.5.1",
-    "serve": "^12.0.0"
+    "serve": "^13.0.2"
   }
 }

--- a/projects/02-data-lovers/package.json
+++ b/projects/02-data-lovers/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run eslint && npm run htmlhint",
     "test": "jest --verbose --coverage",
     "open-coverage-report": "opener ./coverage/lcov-report/index.html",
-    "start": "serve src/",
+    "start": "serve -s src/",
     "deploy": "gh-pages -d src"
   },
   "dependencies": {
@@ -21,6 +21,6 @@
     "htmlhint": "^0.15.1",
     "jest": "^27.0.1",
     "opener": "^1.5.1",
-    "serve": "^12.0.0"
+    "serve": "^13.0.2"
   }
 }

--- a/projects/02-emergency-room/package.json
+++ b/projects/02-emergency-room/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run eslint && npm run htmlhint",
     "test": "jest --coverage",
     "open-coverage-report": "opener ./coverage/lcov-report/index.html",
-    "start": "serve src/",
+    "start": "serve -s src/",
     "deploy": "gh-pages -d src"
   },
   "dependencies": {
@@ -21,6 +21,6 @@
     "htmlhint": "^0.15.1",
     "jest": "^27.0.1",
     "opener": "^1.5.1",
-    "serve": "^12.0.0"
+    "serve": "^13.0.2"
   }
 }

--- a/projects/02-memory-match/package.json
+++ b/projects/02-memory-match/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "jest --coverage",
-    "start": "serve src/",
+    "start": "serve -s src/",
     "deploy": "gh-pages -d src"
   },
   "devDependencies": {
@@ -17,7 +17,7 @@
     "eslint": "^7.27.0",
     "gh-pages": "^3.2.0",
     "jest": "^27.0.1",
-    "serve": "^12.0.0"
+    "serve": "^13.0.2"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/projects/03-social-network/package.json
+++ b/projects/03-social-network/package.json
@@ -15,7 +15,7 @@
     "stylelint": "stylelint --aei src/**/*.css",
     "pretest": "npm run htmlhint && npm run eslint && npm run stylelint",
     "test": "jest --coverage",
-    "start": "serve src/"
+    "start": "serve -s src/"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",
@@ -28,7 +28,7 @@
     "htmlhint": "^0.15.1",
     "jest": "^27.0.1",
     "regenerator-runtime": "^0.13.1",
-    "serve": "^12.0.0",
+    "serve": "^13.0.2",
     "stylelint": "^13.13.1",
     "stylelint-config-recommended": "^5.0.0"
   },


### PR DESCRIPTION
Soluciona #1116 y sube la versión de `serve` a la más nueva.