### PR TITLE
fix(ci-cd)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Change test matrix on `push` job to use node versions 16 and 18 (instead of 14 and 16).