### PR TITLE
📄 docs: fix translation

### DIFF
--- a/projects/02-data-lovers/README.pt-BR.md
+++ b/projects/02-data-lovers/README.pt-BR.md
@@ -62,7 +62,7 @@ Este são os dados que propomos:
   - [Pesquisa com jogadores de Pokémon Go](src/data/pokemon/README.pt-BR.md)
 
 * [League of Legends - Challenger leaderboard](src/data/lol/lol.json): Este
-  conjunto mostra a lista de jogadores de uma liga do jogo League of Legends
+  conjunto mostra a lista de campeões do jogo League of Legends
   (LoL).
   - [Pesquisa com jogadores de LoL](src/data/lol/README.pt-BR.md)
 


### PR DESCRIPTION
Fixing un error de traducción en la explicación de la data de League of Legends

Una estudiante me he apuntado y es correcto:
La data es sobre los champions (campeões) del juego y no sobre los jugadores (jogadores)