### PR TITLE
enhancement(content): a11y Objetivos de Aprendizaje

### DIFF
--- a/learning-objectives/data.yml
+++ b/learning-objectives/data.yml
@@ -58,6 +58,100 @@ js:
     # - async/await
     # - streams
 
+a11y:
+  - perceivable:
+    - level-A
+    - level-AA
+  - operable:
+    - level-A
+    - level-AA
+  - understandable:
+    - level-A
+    - level-AA
+  - robust:
+    - level-A
+    - level-AA
+  - testing: 
+    - audit
+    - assistive-technologies
+
+# another form of grouping with principales and guidelines
+# a11y:
+# - perceivable:
+#   - text-alternatives
+#   - time-based-media
+#   - adaptable-content
+#   - distinguishable-content
+# - operable:
+#   - keyboard-accessible
+#   - enough-time
+#   - seizures-physical-reactions
+#   - navigable 
+#   - input-modalities
+# - understandable:
+#   - readable
+#   - predictable
+#   - input-assistance
+# - robust:
+#   - compatible
+
+# another form of grouping with principales and criteria
+# - a11y:
+#   - perceivable:
+#     - non-text-content
+#     - audio-video-only
+#     - captions
+#     - media-alternative
+#     - captions-live
+#     - audio-description-prerecorded
+#     - info-relationships
+#     - meaningful-sequence
+#     - sensory-characteristics
+#     - orientation
+#     - identify-input-purpose
+#     - use-of-color
+#     - audio-control
+#     - contrast-minimum
+#     - resize-text
+#     - images-text
+#     - reflow
+#     - non-text-contrast
+#     - text-spacing
+#     - content-hover-focus
+#   - operable:
+#     - keyboard
+#     - no-keyboard-trap
+#     - character-key-shortcuts
+#     - timing-adjustable
+#     - pause-stop-hide
+#     - three-flashes-or-below
+#     - bypass-blocks
+#     - page-titled
+#     - focus-order
+#     - link-purpose
+#     - multiple-ways
+#     - headings-labels
+#     - focus-visible
+#     - pointer-gestures
+#     - pointer-cancellation
+#     - label-in-name
+#     - motion-actuation
+#   - understandable:
+#     - language-page
+#     - language-parts
+#     - on-focus
+#     - on-input
+#     - consistent-navigation
+#     - consistent-identification
+#     - error-identification
+#     - labels-instructions
+#     - error-suggestion
+#     - error-prevention
+#   - robust:
+#     - parsing
+#     - name-role-value
+#     - status-messages
+
 scm:
   - git:
       - setup


### PR DESCRIPTION
Addresses #1199 

Hay que agregar Objetivos para accesibilidad (a11y) en nuestros proyectos. Estamos en acuerdo que falta eso en nuestra curricula, pero el diablo esta en los detalles, por supuesto. 

Decidí a usar [la estructura de WCAG ](https://www.w3.org/TR/WCAG21/) para no repensar la rueda, nomenclatura etc. Un "pro" de eso es que ellos han pensado mucho en una taxonomía y solo tenemos que copiarla. Un "con" es que los titulos o nombres a veces no son entendibles solo leyendolos y hay que ver un poco más de que se trata cada categoria o concepto.

En este PR puede encontrar 3 maneras a agrupar Objetivos.

**1. 4 principios, 2 niveles (A, AA)** 
   a11y tiene 4 principios: Perceivable, Operable, Understandable, Robust que agrupan pautas. Cada pauta tiene criterios que un sitio tiene que cumplir para alcanzar un nivel de cumplimento (Compliance) (A - basico, AA - acceptable, AAA) 
      `Pros`: muy digestible, corto, si WCAG agrega mas pautas no tenemos que cambiarlos  
      `Con`: hay que investigar de que se trata cada categoria (lxs estudiantes y nosotros coaches) 

**2. 4 principios con las pautas**
   Los OAs consiste de los nombres de pautas dentro cada principio. Puedes [ver eso por un ejemplo](https://coda.io/d/a11y-Bootcamp_dWuo7bpUXjF/OAs-de-Pautas-de-4-Principios_susBJ#_luPcR) de como `es.yml` puede parecer 
     `Pros`: mas detalle de el anterior, etiquetas/titulos mas descriptivas y transmitir mas la tema (mas memorable?)
     `Con`: si WCAG agrega mas pautas tenemos que actualizarlos, aun hay que investigar de que se trata cada categoria (lxs estudiantes y nosotros coaches) 

**3. 4 principios y sus criterios**  
Los OAs consiste de los nombres de criterios dentro cada pauta. Solo incluye criterios A y AA. Quiza no tenemos incluir todos A y AA, solo los criterios que tiene sentido para nuestro curricula.
   `Pros`: mas detalle de el anterior, etiquetas/titulos mas descriptivas que transmiten mas su idea (mas memorable?)
    `Con`: demasiado largo la lista, pero podemos elegir algunas que nos sirve

Quiero que encontremos un balance de detalle en los OAs pero también algo que podemos guíar sin un monton de trabajo o expertise 

Me gustaria feedback de que camino parece mejor, antes que hacer los `es.yml` y `pt.yml` en este misma PR.



