### PR TITLE
agrega titulos a OAs 

### DIFF
--- a/learning-objectives/intl/es.yml
+++ b/learning-objectives/intl/es.yml
@@ -307,6 +307,8 @@ scm/github/ci:
 
 ux: UX (User eXperience)
 
+user-centricity: Centrado en el usuario
+
 user-centricity/centricity:
   title: Diseñar y desarrollar un producto o servicio poniendo a las usuarias en el centro
 
@@ -315,6 +317,8 @@ user-centricity/user-oriented:
 
 user-centricity/prioritization:
   title: Identificar y priorizar usuarias relevantes para el proyecto
+
+business: Negocio
 
 business/model:
   title: Entender el modelo de negocio
@@ -327,6 +331,8 @@ business/metrics:
 
 business/benchmark:
   title: Entender estado del negocio en relación con el mercado local y global
+
+research: Investigación
 
 research/planning:
   title: Planificar investigación basada en las necesidades del proyecto
@@ -360,6 +366,8 @@ research/test:
 research/cuantitative-data:
   title: Recopilar, analizar e interpretar data cuantitativa
 
+synthesis: Síntesis
+
 synthesis/weighing:
   title: Distinguir observaciones, data y/o respuestas que aportan valor al proyecto
 
@@ -380,6 +388,8 @@ synthesis/ideation:
 
 synthesis/feature-prioritization:
   title: Priorizar las posibles soluciones que aporten más valor al proyecto, basándose en los objetivos del proyecto y las necesidades de los usuarios
+
+product-design: Deseño de producto
 
 product-design/user-flows:
   title: Priorizar y proponer flujos de usuaria que les ayuden a conseguir sus objetivos con el producto
@@ -411,6 +421,8 @@ product-design/project-organization:
 product-design/documentation:
   title: Documentar los distintos componentes de UI y sus casos de uso
 
+communication: Comunicación
+
 communication/presentation:
   title: Presentar y sustentar propuestas a clientes
 
@@ -423,8 +435,10 @@ communication/relationship-management:
 communication/case-study:
   title: Presentar su proceso de trabajo en un caso de estudio usando herramientas de storytelling 
 
+planning: Planificación
+
 planning/monitor:
-  title: Organizar  y dar seguimiento a actividades a desarrollarse durante el proyecto
+  title: Organizar y dar seguimiento a actividades a desarrollarse durante el proyecto
 
 planning/prioritization:
   title: Priorizar actividades a desarrollarse durante el proyecto

--- a/learning-objectives/intl/es.yml
+++ b/learning-objectives/intl/es.yml
@@ -8,7 +8,8 @@ description: >
 # Objetivos de aprendizaje #
 ############################
 
-html: HTML
+html:
+  title: HTML
 
 html/semantics:
   title: Uso de HTML semántico
@@ -19,7 +20,8 @@ html/semantics:
     - title: Semantics - MDN Web Docs Glossary
       url: https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML
 
-css: CSS
+css:
+  title: CSS
 
 css/selectors:
   title: Uso de selectores de CSS
@@ -67,9 +69,11 @@ css/media-queries:
     - title: CSS media queries - MDN
       url: https://developer.mozilla.org/es/docs/CSS/Media_queries
 
-browser: Web APIs
+browser:
+  title: Web APIs
 
-browser/dom: DOM (Document Object Model)
+browser/dom:
+  title: DOM (Document Object Model)
 
 browser/dom/selectors:
   title: Uso de selectores del DOM
@@ -127,7 +131,8 @@ browser/fetch:
     - title: Fetch API - MDN
       url: https://developer.mozilla.org/es/docs/Web/API/Fetch_API
 
-js: JavaScript
+js:
+  title: JavaScript
 
 js/data-types/primitive:
   title: Tipos de datos primitivos
@@ -305,9 +310,11 @@ scm/github/project-management:
 scm/github/ci:
   title: "GitHub: Integración continua con GitHub actions"
 
-ux: UX (User eXperience)
+ux:
+  title: UX (User eXperience)
 
-user-centricity: Centrado en el usuario
+user-centricity:
+  title: Centrado en el usuario
 
 user-centricity/centricity:
   title: Diseñar y desarrollar un producto o servicio poniendo a las usuarias en el centro
@@ -318,7 +325,8 @@ user-centricity/user-oriented:
 user-centricity/prioritization:
   title: Identificar y priorizar usuarias relevantes para el proyecto
 
-business: Negocio
+business:
+  title: Negocio
 
 business/model:
   title: Entender el modelo de negocio
@@ -332,7 +340,8 @@ business/metrics:
 business/benchmark:
   title: Entender estado del negocio en relación con el mercado local y global
 
-research: Investigación
+research:
+  title: Investigación
 
 research/planning:
   title: Planificar investigación basada en las necesidades del proyecto
@@ -366,7 +375,8 @@ research/test:
 research/cuantitative-data:
   title: Recopilar, analizar e interpretar data cuantitativa
 
-synthesis: Síntesis
+synthesis:
+  title: Síntesis
 
 synthesis/weighing:
   title: Distinguir observaciones, data y/o respuestas que aportan valor al proyecto
@@ -389,7 +399,8 @@ synthesis/ideation:
 synthesis/feature-prioritization:
   title: Priorizar las posibles soluciones que aporten más valor al proyecto, basándose en los objetivos del proyecto y las necesidades de los usuarios
 
-product-design: Diseño de producto
+product-design:
+  title: Diseño de producto
 
 product-design/user-flows:
   title: Priorizar y proponer flujos de usuaria que les ayuden a conseguir sus objetivos con el producto
@@ -421,7 +432,8 @@ product-design/project-organization:
 product-design/documentation:
   title: Documentar los distintos componentes de UI y sus casos de uso
 
-communication: Comunicación
+communication:
+  title: Comunicación
 
 communication/presentation:
   title: Presentar y sustentar propuestas a clientes
@@ -435,7 +447,8 @@ communication/relationship-management:
 communication/case-study:
   title: Presentar su proceso de trabajo en un caso de estudio usando herramientas de storytelling 
 
-planning: Planificación
+planning:
+  title: Planificación
 
 planning/monitor:
   title: Organizar y dar seguimiento a actividades a desarrollarse durante el proyecto
@@ -446,7 +459,8 @@ planning/prioritization:
 planning/tools:
   title: Elegir las herramientas y métodos a utilizar de acuerdo a las necesidades  del proyecto
 
-firebase: Firebase
+firebase:
+  title: Firebase
 
 firebase/auth:
   title: Firebase Auth
@@ -514,7 +528,8 @@ node/process:
     - title: Process - Documentación oficial (en inglés)
       url: https://nodejs.org/api/process.html
 
-express: Express.js
+express:
+  title: Express.js
 
 express/routing:
   title: Manejo de rutas
@@ -522,7 +537,8 @@ express/routing:
 express/middleware:
   title: Uso y creación de middleware
 
-socket-io: Socket.IO
+socket-io:
+  title: Socket.IO
 
 socket-io/client:
   title: Cliente JavaScript de Socket.io
@@ -530,7 +546,8 @@ socket-io/client:
 socket-io/server:
   title: Servidor de Node.js de Socket.io
 
-http: HTTP
+http:
+  title: HTTP
 
 http/request-response:
   title: Consulta o petición (request) y respuesta (response).
@@ -578,7 +595,8 @@ http/cors:
     - title: Control de acceso HTTP (CORS) - MDN
       url: https://developer.mozilla.org/es/docs/Web/HTTP/CORS
 
-auth: Autenticación
+auth:
+  title: Autenticación
 
 auth/jwt:
   title: JWT (JSON Web Token)
@@ -586,7 +604,8 @@ auth/jwt:
 auth/password-access-and-storage:
   title: Almacenamiento y acceso de contraseñas
 
-webops: WebOps
+webops:
+  title: WebOps
 
 webops/env-vars:
   title: Variables de entorno
@@ -600,7 +619,8 @@ webops/docker-compose:
 webops/cloud-functions:
   title: Cloud Functions
 
-cicd: Integración Continua/Entrega Continua
+cicd:
+  title: Integración Continua/Entrega Continua
 
 cicd/build-pipelines:
   title: Construcción de pipelines (GitHub Actions/CircleCI)
@@ -617,7 +637,8 @@ cicd/test-coverage:
 cicd/integration-tests:
   title: Pruebas de integración
 
-db: Bases de datos
+db:
+  title: Bases de datos
 
 db/modeling:
   title: Modelado de datos
@@ -628,7 +649,8 @@ db/connection:
 db/indexes-constraints:
   title: Índices y limitaciones
 
-sql: SQL
+sql:
+  title: SQL
 
 sql/tables:
   title: Creación y modificación de tablas
@@ -660,7 +682,8 @@ sql/drop:
     - title: DROP DATABASE
       url: https://www.postgresql.org/docs/8.2/sql-dropdatabase.html
 
-mongodb: MongoDB
+mongodb:
+  title: MongoDB
 
 mongodb/crud:
   title: Operaciones CRUD (Create-Read-Update-Delete)
@@ -693,7 +716,8 @@ mongodb/dump-restore:
     - title: MongoDB Backup Methods - Docs (en inglés)
       url: https://docs.mongodb.com/manual/core/backups/
 
-postgres: PostgreSQL
+postgres:
+  title: PostgreSQL
 
 postgres/psql:
   title: Cliente de terminal psql
@@ -719,7 +743,8 @@ postgres/dump-restore:
     - title: Chapter 26. Backup and Restore - Docs (en inglés)
       url: https://www.postgresql.org/docs/14/backup.html
 
-mysql: MySQL
+mysql:
+  title: MySQL
 
 mysql/mysql:
   title: Cliente de terminal mysql
@@ -747,7 +772,8 @@ mysql/dump-restore:
     - title: mysqldump — A Database Backup Program - Docs (en inglés)
       url: https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html
 
-react: React
+react:
+  title: React
 
 react/jsx:
   title: JSX
@@ -803,7 +829,8 @@ react/routing:
     - title: Quick Start - Documentación oficial (en inglés)
       url: https://reactrouter.com/web/guides/quick-start
 
-vue: Vue
+vue:
+  title: Vue
 
 vue/instance:
   title: Instancia de Vue.js
@@ -867,7 +894,8 @@ vue/classes-and-styles:
     - title: Enlace Clases y Estilos - Documentación oficial
       url: https://es.vuejs.org/v2/guide/class-and-style.html
 
-angular: Angular
+angular:
+  title: Angular
 
 angular/components-and-templates:
   title: Components & templates
@@ -919,7 +947,8 @@ angular/styles:
     - title: Template syntax - Documentación oficial (en inglés)
       url: https://angular.io/guide/template-syntax#built-in-directives
 
-slack: Slack
+slack:
+  title: Slack
 
 slack/slash-commands:
   title: Slash commands de Slack
@@ -927,7 +956,8 @@ slack/slash-commands:
     - title: Enabling interactivity with Slash Commands - Slack Docs
       url: https://api.slack.com/interactivity/slash-commands
 
-php: PHP
+php:
+  title: PHP
 
 php/data-types/primitive:
   title: Tipos de datos primitivos en PHP
@@ -995,7 +1025,8 @@ php/package-management/composer:
     - title: Composer
       url: https://getcomposer.org/doc/00-intro.md
 
-wordpress: WordPress
+wordpress:
+  title: WordPress
 
 wordpress/plugin-development/hooks:
   title: "Hooks: action y filter"

--- a/learning-objectives/intl/es.yml
+++ b/learning-objectives/intl/es.yml
@@ -389,7 +389,7 @@ synthesis/ideation:
 synthesis/feature-prioritization:
   title: Priorizar las posibles soluciones que aporten más valor al proyecto, basándose en los objetivos del proyecto y las necesidades de los usuarios
 
-product-design: Deseño de producto
+product-design: Diseño de producto
 
 product-design/user-flows:
   title: Priorizar y proponer flujos de usuaria que les ayuden a conseguir sus objetivos con el producto

--- a/learning-objectives/intl/pt.yml
+++ b/learning-objectives/intl/pt.yml
@@ -306,14 +306,20 @@ scm/github/ci:
 
 ux: UX (User eXperience)
 
+user-centricity: Centrado no usuário
+
 user-centricity/centricity:
   title: Desenhar e desenvolver um produto ou serviço colocando as usuárias no centro
+
+product-design: Design de produto
 
 product-design/interactivity:
   title: Criar protótipos para obter feedback e iterar
 
 product-design/visual-design:
   title: Aplicar os princípios de desenho visual (contraste, alinhamento, hierarquia)
+
+research: Pesquisar
 
 research/test:
   title: Planejar e executar testes de usabilidade

--- a/learning-objectives/intl/pt.yml
+++ b/learning-objectives/intl/pt.yml
@@ -319,7 +319,7 @@ product-design/interactivity:
 product-design/visual-design:
   title: Aplicar os princípios de desenho visual (contraste, alinhamento, hierarquia)
 
-research: Pesquisar
+research: Pesquisa
 
 research/test:
   title: Planejar e executar testes de usabilidade

--- a/learning-objectives/intl/pt.yml
+++ b/learning-objectives/intl/pt.yml
@@ -8,7 +8,8 @@ description: >
 # Objetivos de aprendizagem #
 #############################
 
-html: HTML
+html:
+  title: HTML
 
 html/semantics:
   title: Uso de HTML semântico
@@ -18,7 +19,8 @@ html/semantics:
     - title: Semantics in HTML - MDN
       url: https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML
 
-css: CSS
+css:
+  title: CSS
 
 css/selectors:
   title: Uso de seletores de CSS
@@ -66,9 +68,11 @@ css/media-queries:
     - title: CSS media queries - MDN
       url: https://developer.mozilla.org/pt-BR/docs/Web/CSS/Media_Queries/Using_media_queries
 
-browser: Web APIs
+browser:
+  title: Web APIs
 
-browser/dom: DOM (Document Object Model)
+browser/dom:
+  title: DOM (Document Object Model)
 
 browser/dom/selectors:
   title: Uso de seletores de DOM
@@ -126,7 +130,8 @@ browser/fetch:
     - title: Fetch API - MDN
       url: https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API
 
-js: JavaScript
+js:
+  title: JavaScript
 
 js/data-types/primitive:
   title: Tipos de dados primitivos
@@ -304,14 +309,17 @@ scm/github/project-management:
 scm/github/ci:
   title: "GitHub: Integração contínua com GitHub actions"
 
-ux: UX (User eXperience)
+ux:
+  title: UX (User eXperience)
 
-user-centricity: Centrado no usuário
+user-centricity:
+  title: Centrado no usuário
 
 user-centricity/centricity:
   title: Desenhar e desenvolver um produto ou serviço colocando as usuárias no centro
 
-product-design: Design de produto
+product-design:
+  title: Design de produto
 
 product-design/interactivity:
   title: Criar protótipos para obter feedback e iterar
@@ -319,12 +327,14 @@ product-design/interactivity:
 product-design/visual-design:
   title: Aplicar os princípios de desenho visual (contraste, alinhamento, hierarquia)
 
-research: Pesquisa
+research:
+  title: Pesquisa
 
 research/test:
   title: Planejar e executar testes de usabilidade
 
-firebase: Firebase
+firebase:
+  title: Firebase
 
 firebase/auth:
   title: Firebase Auth
@@ -392,7 +402,8 @@ node/process:
     - title: Process - Documentação oficial (em inglês)
       url: https://nodejs.org/api/process.html
 
-express: Express.js
+express:
+  title: Express.js
 
 express/routing:
   title: Gerenciamento de rotas
@@ -400,7 +411,8 @@ express/routing:
 express/middleware:
   title: Uso e criação de middleware
 
-socket-io: Socket.IO
+socket-io:
+  title: Socket.IO
 
 socket-io/client:
   title: Cliente JavaScript de Socket.io
@@ -408,7 +420,8 @@ socket-io/client:
 socket-io/server:
   title: Servidor de Node.js de Socket.io
 
-http: HTTP
+http:
+  title: HTTP
 
 http/request-response:
   title: Consulta ou solicitação (request) e resposta (response).
@@ -456,7 +469,8 @@ http/cors:
     - title: Cross-Origin Resource Sharing (CORS) - MDN
       url: https://developer.mozilla.org/pt-BR/docs/Web/HTTP/CORS
 
-auth: Autenticação
+auth:
+  title: Autenticação
 
 auth/jwt:
   title: JWT (JSON Web Token)
@@ -464,7 +478,8 @@ auth/jwt:
 auth/password-access-and-storage:
   title: Armazenamento e acesso de senhas
 
-webops: WebOps
+webops:
+  title: WebOps
 
 webops/env-vars:
   title: Variáveis de ambiente
@@ -478,7 +493,8 @@ webops/docker-compose:
 webops/cloud-functions:
   title: Cloud Functions
 
-cicd: Integração Contínua/Entrega Contínua
+cicd:
+  title: Integração Contínua/Entrega Contínua
 
 cicd/build-pipelines:
   title: Construção de pipelines (GitHub Actions/CircleCI)
@@ -495,7 +511,8 @@ cicd/test-coverage:
 cicd/integration-tests:
   title: Testes de integração
 
-db: Bases de dados
+db:
+  title: Bases de dados
 
 db/modeling:
   title: Modelagem de dados
@@ -506,7 +523,8 @@ db/connection:
 db/indexes-constraints:
   title: Índices e limitações
 
-sql: SQL
+sql:
+  title: SQL
 
 sql/tables:
   title: Criação e modificação de tabelas
@@ -538,7 +556,8 @@ sql/drop:
     - title: DROP DATABASE
       url: https://www.postgresql.org/docs/8.2/sql-dropdatabase.html
 
-mongodb: MongoDB
+mongodb:
+  title: MongoDB
 
 mongodb/crud:
   title: Operações CRUD (Create-Read-Update-Delete)
@@ -571,7 +590,8 @@ mongodb/dump-restore:
     - title: MongoDB Backup Methods - Docs (em inglês)
       url: https://docs.mongodb.com/manual/core/backups/
 
-postgres: PostgreSQL
+postgres:
+  title: PostgreSQL
 
 postgres/psql:
   title: Cliente de terminal psql
@@ -597,7 +617,8 @@ postgres/dump-restore:
     - title: Chapter 26. Backup and Restore - Docs (em inglês)
       url: https://www.postgresql.org/docs/14/backup.html
 
-mysql: MySQL
+mysql:
+  title: MySQL
 
 mysql/mysql:
   title: Cliente de terminal mysql
@@ -625,7 +646,8 @@ mysql/dump-restore:
     - title: mysqldump — A Database Backup Program - Docs (em inglês)
       url: https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html
 
-react: React
+react:
+  title: React
 
 react/jsx:
   title: JSX
@@ -681,7 +703,8 @@ react/routing:
     - title: Quick Start - Documentação oficial (em inglês)
       url: https://reactrouter.com/web/guides/quick-start
 
-vue: Vue
+vue:
+  title: Vue
 
 vue/instance:
   title: Instância de Vue.js
@@ -745,7 +768,8 @@ vue/classes-and-styles:
     - title: Interligações de Classe e Estilo - Documentação oficial
       url: https://br.vuejs.org/v2/guide/class-and-style.html
 
-angular: Angular
+angular:
+  title: Angular
 
 angular/components-and-templates:
   title: Components & templates
@@ -797,7 +821,8 @@ angular/styles:
     - title: Template syntax - Documentação oficial (em inglês)
       url: https://angular.io/guide/template-syntax#built-in-directives
 
-slack: Slack
+slack:
+  title: Slack
 
 slack/slash-commands:
   title: Slash commands de Slack
@@ -805,7 +830,8 @@ slack/slash-commands:
     - title: Enabling interactivity with Slash Commands - Slack Docs
       url: https://api.slack.com/interactivity/slash-commands
 
-php: PHP
+php:
+  title: PHP
 
 php/data-types/primitive:
   title: Tipos de dados primitivos em PHP
@@ -873,7 +899,8 @@ php/package-management/composer:
     - title: Composer
       url: https://getcomposer.org/doc/00-intro.md
 
-wordpress: WordPress
+wordpress:
+  title: WordPress
 
 wordpress/plugin-development/hooks:
   title: "Hooks: action e filter"


### PR DESCRIPTION
Addresses #1209 

Agregamos `title:` explicitamente a cada encabezado. 
Estes cambios arreglan user centricity y product design en particular.

Aqui es un primer avance, falta:
- [x] version en portugues
- [x] probar si este corrige el error

Probando usando `create-cohort-project` y viendo el resultado
en ES y PT:

https://gist.github.com/unjust/83cba0bc007c2251219bc60286e54fc2

(con `npm run create-cohort-project ./projects/01-cipher  ../../temp TEST-BR -- --locale=pt-BR`)

