### PR TITLE
doc: removed heroku and added glitch & elephantSql

### DIFF
--- a/projects/04-burger-queen-api/README.md
+++ b/projects/04-burger-queen-api/README.md
@@ -223,7 +223,8 @@ explorar las siguientes opciones:
 
 * [Glitch](https://glitch.com) es
   probablemente la opción más _sencilla_ (la que requiere menos configuración) y
-  nos permite alojar el servidor web Express importando nuestro repositorio desde GitHub.
+  nos permite alojar el servidor web Express
+importando nuestro repositorio desde GitHub.
 * Si quieres explorar opciones más personalizadas y ver docker del lado del
   servidor puedes cosiderar proveedores como
   [AWS (Amazon Web Services)](https://aws.amazon.com/) o

--- a/projects/04-burger-queen-api/README.md
+++ b/projects/04-burger-queen-api/README.md
@@ -221,10 +221,9 @@ seleccionada. Por otro lado, con respecto al despliegue, no es obligatorio usar
 con el mecanismo de despligue y estrategia de alojamiento. Te recomendamos
 explorar las siguientes opciones:
 
-* [Heroku](https://devcenter.heroku.com/articles/getting-started-with-nodejs) es
+* [Glitch](https://glitch.com) es
   probablemente la opción más _sencilla_ (la que requiere menos configuración) y
-  nos permite alojar tanto el servidor web como la base de datos (PostgreSQL) en
-  el mismo sitio con pocos clicks.
+  nos permite alojar el servidor web express importando nuestro repositorio desde github
 * Si quieres explorar opciones más personalizadas y ver docker del lado del
   servidor puedes cosiderar proveedores como
   [AWS (Amazon Web Services)](https://aws.amazon.com/) o
@@ -234,6 +233,9 @@ explorar las siguientes opciones:
   aplicaciones en contenedores (por ejemplo [Compute Engine](https://cloud.google.com/compute/docs/containers)
   de GCP o [Elastic Container Service](https://aws.amazon.com/ecs/) de AWS).
 * Si quieres trabajar con MongoDB, [MongoDB Atlas](https://www.mongodb.com/cloud/atlas)
+  es una muy buena opción para alojar nuestra base datos de producción, la cuál
+  podemos usar en conjunción con cualquiera de las opciones mencionadas arriba.
+* Si quieres trabajar con PostgreSql, [ElephantSQL](https://www.mongodb.com/cloud/atlas](https://www.elephantsql.com/plans.html)
   es una muy buena opción para alojar nuestra base datos de producción, la cuál
   podemos usar en conjunción con cualquiera de las opciones mencionadas arriba.
 

--- a/projects/04-burger-queen-api/README.md
+++ b/projects/04-burger-queen-api/README.md
@@ -235,7 +235,7 @@ explorar las siguientes opciones:
 * Si quieres trabajar con MongoDB, [MongoDB Atlas](https://www.mongodb.com/cloud/atlas)
   es una muy buena opción para alojar nuestra base datos de producción, la cuál
   podemos usar en conjunción con cualquiera de las opciones mencionadas arriba.
-* Si quieres trabajar con PostgreSql, [ElephantSQL](https://www.mongodb.com/cloud/atlas](https://www.elephantsql.com/plans.html)
+* Si quieres trabajar con PostgreSql, [ElephantSQL](https://www.elephantsql.com/plans.html)
   es una muy buena opción para alojar nuestra base datos de producción, la cuál
   podemos usar en conjunción con cualquiera de las opciones mencionadas arriba.
 

--- a/projects/04-burger-queen-api/README.md
+++ b/projects/04-burger-queen-api/README.md
@@ -223,7 +223,7 @@ explorar las siguientes opciones:
 
 * [Glitch](https://glitch.com) es
   probablemente la opción más _sencilla_ (la que requiere menos configuración) y
-  nos permite alojar el servidor web express importando nuestro repositorio desde github
+  nos permite alojar el servidor web Express importando nuestro repositorio desde GitHub.
 * Si quieres explorar opciones más personalizadas y ver docker del lado del
   servidor puedes cosiderar proveedores como
   [AWS (Amazon Web Services)](https://aws.amazon.com/) o

--- a/projects/04-burger-queen-api/README.md
+++ b/projects/04-burger-queen-api/README.md
@@ -224,7 +224,7 @@ explorar las siguientes opciones:
 * [Glitch](https://glitch.com) es
   probablemente la opción más _sencilla_ (la que requiere menos configuración) y
   nos permite alojar el servidor web Express
-importando nuestro repositorio desde GitHub.
+  importando nuestro repositorio desde GitHub.
 * Si quieres explorar opciones más personalizadas y ver docker del lado del
   servidor puedes cosiderar proveedores como
   [AWS (Amazon Web Services)](https://aws.amazon.com/) o


### PR DESCRIPTION
Se propone quitar Heroku de las opciones de despliegue ya que en 3 semanas finaliza su capa gratuita, una buena alternativa es Glitch que tiene soporte para node y expressJS. Adicionalmente se sugiere ElephantSQL para quienes deseen desplegar una base de datos relacional de Postgresql, este servicio también cuenta con una capa gratuita