### PR TITLE
Changes to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Cómo contribuir a este repo
 
 Este repositorio es un recurso abierto, y como tal estamos todos invitados a
-participar.
+participar. 
 
 ## Sugerencias, errores y comentarios generales
 
@@ -10,9 +10,28 @@ El lugar donde empezar es nuestro
 puedes buscar y ver si tu pregunta o sugerencia ya se ha preguntado antes,
 participar en discusiones relevantes y añadir nuevos _issues_.
 
-## Ayuda con review, validación y sugerencias de contenido
+## Para ayudar con review, validación y sugerencias de contenido
 
 Busca _issues_ con los tags [`help-wanted`](https://github.com/Laboratoria/bootcamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+### Git workflow
+
+En el repo seguimos un modelo de colaboración basado en forks.
+__Cada una trabaja en su fork.__ Como repo público cualquiera puede
+hacer un fork en su cuenta, hacer los cambios que considere y enviar
+propuestas de cambios desde su fork en un pull request (PR).
+
+* Cambios (PRs) normalmente se envían de una rama de su fork a Laboratoria/main.
+* Toda propuesta de cambios (PR) tendrá que pasar peer-review y tareas de validación,
+  linting y pruebas unitarias (npm test).
+* Antes de enviar un PR siempre revisa primero el issue tracker para ver si ya existe
+  una conversación al respecto.
+
+Si no estás segura de cómo enviar un PR o si deberías hacerlo, lo mejor es comenzar
+por un issue.
+Si son cambios menores, o tienes muy claro qué cambiar y cómo,
+lo ideal es pull request directamente y describir el issue/error
+en la descripción de PR.
 
 ## Creación de contenido
 
@@ -21,3 +40,44 @@ Si tienes una idea para un curso, chequea el
 [`README.md`](README.md) para ver si ya se ha propuesto algo parecido. Si tu
 propuesta es algo nuevo, abre un issue con tu idea y veamos que opina la
 comunidad.
+
+En el repo tenemos dos tipos de contenido: topicos y proyectos, cada una tiene
+una desarolla una poca distina.
+
+### Topicos
+
+Un topico siguen un formato en particular. Nuevos topicos necesitan nuevo directorio
+dentro de carpeta `topic` con el nombre de topic, y dentro eso creas directorios por casa "capitulo".
+
+En el directorio `topics` de proyecto encuentras un `_template` que puede seguir. 
+
+CUando estas haciendo contenido o cambios puedes visualizar los cambios corriendo el sitio
+de curricula localmente con estos pasos:
+
+1. corre `npm build:content` para crear/actualizar el contenido topicos
+2. `npm run test:topics o pretest ?`
+3. corre `npm run build` para hacer los componentes de sitio
+4. correr `npm start` para correr el server y navegar al sitio, o `npm run watch` si quiere..
+    
+
+### Proyectos
+
+Puedes encontrar los proyectos dentro `projects`. Cada proyecto tiene su propio carpeta con un 
+boilerplate. Los READMEs son generado con un script que incluye los Objetivos de Aprendizaje 
+en una manera automatizado. 
+
+Si haces cambios a un README y o agregas objetivos de aprendizaje al proyecto 
+y quieres ver como parece en su totalidad,
+usa (`create-cohort-project` script)[scripts/README.md#scripts-para-coaches] para generar
+el repo localmente (no tienes que epujer el repo).
+
+Si haces cambios con un impacto a boilerplate o creas un proyecto nuevo,
+seria bueno tener un ejemplo de implementacion, un proyecto desplegada para probarlo.
+
+md lint?
+
+### Learning Objectives 
+
+...
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ El lugar donde empezar es nuestro
 puedes buscar y ver si tu pregunta o sugerencia ya se ha preguntado antes,
 participar en discusiones relevantes y añadir nuevos _issues_.
 
-## Para ayudar con review, validación y sugerencias de contenido
+### Para ayudar con review, validación y sugerencias de contenido
 
 Busca _issues_ con los tags [`help-wanted`](https://github.com/Laboratoria/bootcamp/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+## Temas de Desarollo 
 
 ### Git workflow
 
@@ -32,6 +34,10 @@ por un issue.
 Si son cambios menores, o tienes muy claro qué cambiar y cómo,
 lo ideal es pull request directamente y describir el issue/error
 en la descripción de PR.
+
+### Estilo de codigo
+
+Link to wiki
 
 ## Creación de contenido
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,6 +2,15 @@
 
 Descripción de los pasos a seguir para realizar el despliegue.
 
+Para preparar el release:
+
+1. Ejecutar el comando para ver si necesitamos actualizar las dependencias de proyecto
+  `npm outdated —depth 0`. 
+2. Revisa/compara si las versiones son actualizados, y si no, si podemos actualizarlo
+  (revisando que se trata el nuevo version, si va a romper algo o no, puede actualizarlo localmente y probar)
+3. Empieza escribir un nuevo log de version en github. Va a incluir el changelog y en casos de version 
+  mayor, una descripción.
+
 ⚠️ Antes de hacer un tag de release, es imprescindible:
 
 1. Ejecutar comando `npm run changelog` y actualizar release en Github


### PR DESCRIPTION
Tenemos un wiki con contenido y varios READMEs que podemos linkear/actualizar para describir el proceso de contributing mas clara.

[ ] Agregamos secciones a CONTRIBUTING con contenido de wiki y como contribuir contenido en particular (topics, projects, OAs)
[ ] Agregamos pasos que falta a DEPLOYMENT
[ ] Linkear contributing al README principal
[ ] Borrar partes a wiki pero quiza quedamos con styleguides alla, y linkeamos esos al README contributing