### PR TITLE
some improvements for cipher project

### DIFF
--- a/projects/01-cipher/README.md
+++ b/projects/01-cipher/README.md
@@ -16,7 +16,9 @@
 
 ## 1. Preámbulo
 
-Cifrar significa codificar. El [cifrado César](https://en.wikipedia.org/wiki/Caesar_cipher)
+Cifrar significa ocultar el contenido de un mensaje a simple vista, de manera
+que sólo las partes autorizadas pueden descifrar un texto cifrado.
+El [cifrado César](https://en.wikipedia.org/wiki/Caesar_cipher)
 es uno de los primeros métodos de cifrado conocidos. El emperador romano Julio
 César lo usaba para enviar órdenes secretas a sus generales en los campos de
 batalla.
@@ -75,7 +77,7 @@ conceptos también.
 
 ## 3. Consideraciones generales
 
-* Este proyecto lo resolvemos de manera individual. Te recomendamos una
+* Este proyecto lo resolvemos de manera **individual**. Te recomendamos una
   duracion de 1-3 sprints.
 * Enfócate en aprender y no solamente en "completar" el proyecto.
 * Te sugerimos que no intentes saberlo todo antes de empezar a codear.
@@ -237,8 +239,7 @@ El comando `npm run deploy` puede ayudarte con esta tarea y también puedes
 ### Prepara tu PC para trabajar
 
 1. Asegúrate de tener un :pencil: editor de texto en
-   condiciones, algo como [Atom](https://atom.io/) o
-   [Code](https://code.visualstudio.com/).
+   condiciones, algo como [VS Code](https://code.visualstudio.com/).
 2. Para ejecutar los comandos a continuación necesitarás una :shell:
    [UNIX Shell](https://curriculum.laboratoria.la/es/topics/shell),
    que es un programa que interpreta líneas de comando (command-line
@@ -246,15 +247,10 @@ El comando `npm run deploy` puede ayudarte con esta tarea y también puedes
    instalado. Si usas un sistema operativo "UNIX-like", como GNU/Linux o MacOS,
    ya tienes una _shell_ (terminal) instalada por defecto (y probablemente `git`
    también). Si usas Windows puedes usar la versión completa de [Cmder](https://cmder.app/)
-   que incluye [Git bash](https://git-scm.com/download/win) y si tienes Windows
-   10 o superior puedes usar [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-3. Una de las integrantes del equipo debe realizar un :fork_and_knife:
-   [fork](https://help.github.com/articles/fork-a-repo/) del repo de tu cohort,
-   tus _coaches_ te compartirán un _link_ a un repo y te darán acceso de lectura
-   en ese repo. La otra integrante del equipo deber hacer un fork **del
-   repositorio de su compañera** y
-   [configurar](https://gist.github.com/BCasal/026e4c7f5c71418485c1) un `remote`
-   hacia el mismo.
+   que incluye [Git bash](https://git-scm.com/download/win).
+3. Tus _coaches_ te compartirán un _link_ a un repo y te darán acceso de lectura
+   en ese repo. Debes realizar un :fork_and_knife:
+   [fork](https://help.github.com/articles/fork-a-repo/) del repo.
 4. :arrow_down: [Clona](https://help.github.com/articles/cloning-a-repository/)
    tu _fork_ a tu computadora (copia local).
 5. 📦 Instala las dependencias del proyecto con el comando `npm install`. Esto
@@ -297,7 +293,6 @@ Desarrollo Front-end:
 * [Aprende más sobre `ASCII`](http://conceptodefinicion.de/ascii/)
 * Aprende más sobre [objetos](https://es.javascript.info/object) y
   [como definir métodos](https://developer.mozilla.org/es/docs/Web/JavaScript/Guide/Working_with_Objects#definici%C3%B3n_de_m%C3%A9todos)
-* [Documentación de NPM](https://docs.npmjs.com/)
 
 Organización del Trabajo:
 

--- a/projects/01-cipher/README.pt-BR.md
+++ b/projects/01-cipher/README.pt-BR.md
@@ -16,7 +16,9 @@
 
 ## 1. Prefácio
 
-Cifrar significa codificar. A [cifra de César](https://pt.wikipedia.org/wiki/Cifra_de_C%C3%A9sar)
+Encriptar significa ocultar o conteúdo de uma mensagem a olho nu,
+para que somente as partes autorizadas possam decifrar um texto cifrado.
+A [cifra de César](https://pt.wikipedia.org/wiki/Cifra_de_C%C3%A9sar)
 é um dos primeiros tipos de criptografias conhecidas na história.
 O imperador romano Júlio César utilizava essa cifra para enviar
 ordens secretas aos seus generais no campo de batalha.
@@ -73,7 +75,7 @@ bem como eventos e manipulação básica de DOM, fundamentos HTML e CSS.
 
 ## 3. Considerações gerais
 
-* Resolvemos este projeto individualmente. Recomendamos uma duração de 1-3 sprints.
+* Resolvemos este projeto **individualmente**. Recomendamos uma duração de 1-3 sprints.
 * Concentre-se em aprender e não apenas "concluir" o projeto.
 * Sugerimos que você não tente saber tudo antes de começar a codificar.
   Não se preocupe muito agora com o que você _ainda_ não entende.
@@ -232,7 +234,7 @@ consultar a [documentação oficial](https://docs.github.com/pt/pages).
 ### Primeiros passos
 
 1. Se assegure de ter um bom :pencil: editor de texto, algo
-   como [Code](https://code.visualstudio.com/) ou [Atom](https://atom.io/).
+   como [VS Code](https://code.visualstudio.com/).
 2. Para executar os comandos você precisará de um :shell: UNIX Shell, que é um
    programa que interpreta linhas de comando (command-line interpreter) e também
    deve ter o git instalado. Se você usa um sistema operacional "UNIX-like",
@@ -276,7 +278,6 @@ Desenvolvimento Front-end:
   `String.fromCharCode()`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode)
 * [Aprenda mais sobre
   `ASCII`](https://web.fe.up.pt/~ee96100/projecto/Tabela%20ascii.htm)
-* [Documentação do NPM](https://docs.npmjs.com/)
 * Saiba mais sobre [objetos](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Guide/Working_with_Objects)
   e [como definir métodos](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Guide/Working_with_Objects#definindo_m%C3%A9todos##)
 


### PR DESCRIPTION
Propongo los siguientes cambios:

- En la seccion Preámbulo mejorar la explicacion sobre qué es cifrar
- En la seccion "8. Pistas, tips y lecturas complementarias", subseccion "Prepara tu PC para trabajar":
1. Eliminar referencia a Atom porque ya esta deprecated
2. Eliminar referencia a Windows Subsystem for Linux. Propongo eliminarlo porque las estudiantes suelen confundirse con esto e intentan configurar el WSL junto con Cmder y Git bash. Considero que es mejor si les ahorramos esta confucion. Por otro lado, en mi experiencia personal, WSL suele ser exigente para la máquina y supongo que las estudiantes que no tengan un computador bueno tendrian problemas. Y finalmente me parece un poco exagerado configurar todo WSL para algo sencillo como el primer proyecto. Dejo abierta la discusion.
3. En la parte que habla de hacer un fork decia "La otra integrante del equipo deber hacer un fork " pero este proyecto es individual, entonces lo modifiqué.
4. En la seccion "Recursos y temas relacionados", elimine el link "Documentación de NPM" porque no es necseario revisarla para completar el proyecto.

Pendiente:

- Hacer estos mismo cambios en la version de portugués
