### PR TITLE
feat(hosting): Agrega redirects de track js a web-dev

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -21,6 +21,16 @@
         "regex": "/(es|pt)/topics/([a-z0-9\\-]+)/\\d{2}-([a-z0-9\\-]+)",
         "destination": "/:1/topics/:2/:3",
         "type": 301
+      },
+      {
+        "regex": "/(es|pt)/js/(topics|gym)",
+        "destination": "/:1/web-dev/:2",
+        "type": 301
+      },
+      {
+        "regex": "/(es|pt)/js",
+        "destination": "/:1/web-dev",
+        "type": 301
       }
     ],
     "rewrites": [


### PR DESCRIPTION
En `v6.0.0` el track de `js` de renombra oficialmente a `web-dev` de acuerdo con `@laboratoria/core`, por ende cambian las URLs que contenían `js` como representación del track.