### PR TITLE
fix(bug): use the package json of project, not repo in general

### DIFF
--- a/scripts/create-cohort-project.mjs
+++ b/scripts/create-cohort-project.mjs
@@ -92,7 +92,7 @@ const addBootcampInfo = async (repoDir) => {
   if (!existsSync(projectPkgJsonPath)) {
     return;
   }
-  const pkg = Object.assign(JSON.parse(await readFile('package.json')), {
+  const pkg = Object.assign(JSON.parse(await readFile(projectPkgJsonPath)), {
     bootcamp: {
       createdAt: (new Date()).toISOString(),
       version: process.env.npm_package_version,


### PR DESCRIPTION
closes #1338 

create-cohort-script estaba copiando el `package.json` de repo bootcamp y copiado al repo de proyecto individual. Deberia tomar el package.json del directorio de proyecto.