### PR TITLE
Agrega codigo necesario por mongoDB setup y spawn en Windows

### DIFF
--- a/projects/04-burger-queen-api/config.js
+++ b/projects/04-burger-queen-api/config.js
@@ -3,3 +3,5 @@ exports.dbUrl = process.env.DB_URL || 'mongodb://localhost:27017/test';
 exports.secret = process.env.JWT_SECRET || 'esta-es-la-api-burger-queen';
 exports.adminEmail = process.env.ADMIN_EMAIL || 'admin@localhost';
 exports.adminPassword = process.env.ADMIN_PASSWORD || 'changeme';
+exports.dbUrl = process.env.MONGO_URL || process.env.DB_URL || 'mongodb://localhost:27017/test';
+exports.dbName = process.env.DB_NAME || 'burgerqueen';

--- a/projects/04-burger-queen-api/e2e/globalSetup.js
+++ b/projects/04-burger-queen-api/e2e/globalSetup.js
@@ -2,6 +2,12 @@ const path = require('path');
 const { spawn } = require('child_process');
 const kill = require('tree-kill');
 
+/* Descomentar eso para mongoDB
+const globalSetup = require("@shelf/jest-mongodb/lib/setup");
+const MongodbMemoryServer = require('mongodb-memory-server').default;
+
+global.__MONGOD__ = MongodbMemoryServer;
+*/
 const config = require('../config');
 
 const port = process.env.PORT || 8888;
@@ -106,9 +112,23 @@ module.exports = () => new Promise((resolve, reject) => {
   }
 
   // TODO: Configurar DB de tests
-
-  console.info('Staring local server...');
-  const child = spawn('npm', ['start', process.env.PORT || 8888], {
+  
+  /* si usas mongoDB
+    globalSetup({rootDir: __dirname}).then(() => {
+      // console.log(global.__MONGOD__);
+      console.info('Starting local server...');
+      const child = spawn("node", [ "index.js", process.env.PORT || 8888], 
+        { 
+          cwd: path.resolve(__dirname, "../"), 
+          stdio: ["ignore", "pipe", "pipe"], 
+          env: { PATH: process.env.PATH, MONGO_URL: process.env.MONGO_URL }
+        }
+      );
+      })
+      .catch((error) => console.log(error));
+  */
+  console.info('Starting local server...');
+  const child = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['start', process.env.PORT || 8888], {
     cwd: path.resolve(__dirname, '../'),
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/projects/04-burger-queen-api/jest-mongodb-config.js
+++ b/projects/04-burger-queen-api/jest-mongodb-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mongodbMemoryServerOptions: {
+    instance: {
+      dbName: 'burger-queen-api',
+    },
+    binary: {
+      version: '4.0.3',
+      skipMD5: true,
+    },
+    autoStart: false,
+  },
+};

--- a/projects/04-burger-queen-api/package.json
+++ b/projects/04-burger-queen-api/package.json
@@ -20,7 +20,8 @@
     "bcrypt": "^5.0.1",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "mongoose": "^6.8.3"
   },
   "devDependencies": {
     "docdash": "^1.2.0",
@@ -31,7 +32,9 @@
     "jest": "^27.0.1",
     "jsdoc": "^3.6.6",
     "jsdoc-http-plugin": "^0.3.2",
+    "mongodb-memory-server": "^8.11.2",
     "node-fetch": "^3.1.0",
+    "@shelf/jest-mongodb": "^4.1.5",
     "tree-kill": "^1.2.2"
   }
 }


### PR DESCRIPTION
Un primer paso para ver el trabajo necesario para configurar MongoDB con los e2e tests.
Tambien una linea para arreglar `spawn` en windows (que no funciona por una estudiante en windows)

Revisando el codigo quiero pensar si decidimos solo ofrecer MongoDB y cambia el codigo de e2e o agregamos un README adicional para MongoDB.

Tambien necesitamos una estrategia a probar eso - un proyecto aparte para probar los cambios o con un estudiante en particular?