### PR TITLE
feat(docs): Adds /no-iframe/ flag to topics/ README's videos we don't…

### DIFF
--- a/topics/content-management/00-information-architecture/00-information-architecture/README.md
+++ b/topics/content-management/00-information-architecture/00-information-architecture/README.md
@@ -81,7 +81,7 @@ los componentes claves de la AI son:
 * [Qué es: Arquitectura de Información (IA)](https://blog.acantu.com/que-es-arquitectura-informacion/)
 * [Cómo definir la arquitectura de la información de un proyecto](https://www.hiberus.com/crecemos-contigo/como-definir-la-arquitectura-de-la-informacion-de-un-proyecto/)
 * [Information architecture basics](https://www.usability.gov/what-and-why/information-architecture.html)
-* [How to make sense of any mess](https://vimeo.com/168194951)
+* [How to make sense of any mess](https://vimeo.com/168194951 "How to make sense of any mess /no-iframe/")
 * [Aprendizajes sobre arquitectura de la información](http://www.icrossing.com/la/ideas/aprendizajes-del-isa-2015-sobre-arquitectura-de-la-informaci%C3%B3n)
 * [Information Architecture: For the Web and Beyond](https://www.amazon.com/Information-Architecture-Beyond-Louis-Rosenfeld/dp/1491911689/ref=sr_1_1?ie=UTF8&qid=1519138195&sr=8-1&keywords=information+architecture&dpID=51gpnrSXHHL&preST=_SY291_BO1,204,203,200_QL40_&dpSrc=srch)
 * [Information Architecture](https://www.pluralsight.com/courses/information-architecture-introduction-2548)

--- a/topics/css/02-responsive/03-rwd/README.pt.md
+++ b/topics/css/02-responsive/03-rwd/README.pt.md
@@ -49,4 +49,4 @@ Você pode conhecer um pouco mais sobre Web Design Responsivo nos links a seguir
   CSS](https://tableless.com.br/imagens-responsivas-de-alta-performance/)
 - [Entendendo a diferença entre *mobile-first*, design responsivo e
   adaptativo](https://medium.com/@fnandaleite/entendendo-as-diferen%C3%A7as-entre-design-responsivo-adaptativo-e-mobile-first-ea3c61fc9181)
-- [Introdução RWD](https://www.youtube.com/watch?v=HZfESVi3Ebk)
+- [Introdução RWD](https://www.youtube.com/watch?v=HZfESVi3Ebk  "Introdução RWD /no-iframe/")

--- a/topics/css/03-frameworks/01-framework/README.md
+++ b/topics/css/03-frameworks/01-framework/README.md
@@ -41,8 +41,13 @@ y conocer mucho mejor CSS!
 
 Aquí te dejamos unos vídeos introductorios a algunos frameworks:
 
-- [Bootstrap](https://youtu.be/_2TLe8DyhEY)
-- [Materialize](https://youtu.be/Plk9vbu7a3c?t=18s)
+### Bootstrap
+
+[Video Bootstrap](https://youtu.be/_2TLe8DyhEY)
+
+### Materialize
+
+[VideoMaterialize](https://youtu.be/Plk9vbu7a3c?t=18s)
 
 Algunas de las herramientas que podemos encontrar en los frameworks de CSS son:
 

--- a/topics/css/03-frameworks/01-framework/README.pt.md
+++ b/topics/css/03-frameworks/01-framework/README.pt.md
@@ -42,9 +42,13 @@ e estilos incríveis e totalmente personalizados, e conhecer muito melhor CSS!
 
 Aqui deixamos alguns vídeos introdutórios a alguns frameworks.
 
-- [Bootstrap](https://www.youtube.com/watch?v=wiq1Zs9-qMQ)
+### Bootstrap
 
-- [Materialize](https://www.youtube.com/watch?v=JNTfjNCBl5c)
+[Video Bootstrap](https://www.youtube.com/watch?v=wiq1Zs9-qMQ)
+
+### Materialize
+
+[Video Materialize](https://www.youtube.com/watch?v=JNTfjNCBl5c)
 
 Algumas das ferramentas que podemos encontrar nos frameworks de CSS são:
 

--- a/topics/functional/03-hof/05-currying/README.md
+++ b/topics/functional/03-hof/05-currying/README.md
@@ -274,8 +274,8 @@ nombrar y manejar los argumentos de la función.
 * [Function.prototype.bind()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
 * [Function.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
 * [Frequently Asked Questions for comp.lang.functional](http://www.cs.nott.ac.uk/~pszgmh/faq.html#currying)
-* [Currying - Part 6 of Functional Programming in JavaScript](https://www.youtube.com/watch?v=iZLP4qOwY8I)
-  por Mattias P Johansson
+* [Currying - Part 6 of Functional Programming in JavaScript por Mattias P Johansson](https://www.youtube.com/watch?v=iZLP4qOwY8I 
+  "Currying - Part 6 of Functional Programming in JavaScript por Mattias P Johansson /no-iframe/")
 
 [Ramda]: http://ramdajs.com/
 [currying]: https://www.sitepoint.com/currying-in-functional-javascript/

--- a/topics/javascript/04-arrays/04-guided-exercises/README.md
+++ b/topics/javascript/04-arrays/04-guided-exercises/README.md
@@ -38,9 +38,9 @@ search`](https://en.wikipedia.org/wiki/Linear_search). Con este ejercicio
 introducimos el concepto de `algoritmo`. Para entender qué es un algoritmo,
 revisa los siguientes videos:
 
-- [Magic Markers: ¿Qué es un algoritmo?](https://www.youtube.com/watch?v=U3CGMyjzlvM)
-- [Kahn Academy: ¿Qué es un algoritmo y por qué debería importarte?]
-  (<https://es.khanacademy.org/computing/computer-science/algorithms/intro-to-algorithms/v/what-are-algorithms>)
+- [Magic Markers: ¿Qué es un algoritmo?](https://www.youtube.com/watch?v=U3CGMyjzlvM
+  "Magic Markers: ¿Qué es un algoritmo? /no-iframe/")
+- [Kahn Academy: ¿Qué es un algoritmo y por qué debería importarte?](https://es.khanacademy.org/computing/computer-science/algorithms/intro-to-algorithms/v/what-are-algorithms)
 
 ## Solucionarios
 

--- a/topics/paradigms/01-paradigms/01-overview/README.md
+++ b/topics/paradigms/01-paradigms/01-overview/README.md
@@ -91,10 +91,11 @@ Blog posts:
 
 Videos:
 
-* [Programming Paradigms](https://www.youtube.com/watch?v=sqV3pL5x8PI),
+* [Programming Paradigms](https://www.youtube.com/watch?v=sqV3pL5x8PI "Programming Paradigms /no-iframe/"),
   `10:43`, [Computerphile](https://www.youtube.com/channel/UC9-y-6csu5WGm29I7JiwpnA),
   30 Aug 2013
-* [HTML IS a Programming Language (Imperative vs Declarative)](https://www.youtube.com/watch?v=4A2mWqLUpzw),
+* [HTML IS a Programming Language (Imperative vs Declarative)](https://www.youtube.com/watch?v=4A2mWqLUpzw 
+  "HTML IS a Programming Language (Imperative vs Declarative) /no-iframe/"),
   `8:27`, [Computerphile](https://www.youtube.com/channel/UC9-y-6csu5WGm29I7JiwpnA),
   Jun 28 2016
 * [Qué es un paradigma de programación](https://www.video2brain.com/mx/tutorial/que-es-un-paradigma-de-programacion),

--- a/topics/paradigms/01-paradigms/03-declarative-vs-imperative/README.md
+++ b/topics/paradigms/01-paradigms/03-declarative-vs-imperative/README.md
@@ -100,7 +100,8 @@ ocurra (el compilador o intérprete se encarga del resto).
 
 Videos:
 
-* [HTML IS a Programming Language (Imperative vs Declarative)](https://www.youtube.com/watch?v=4A2mWqLUpzw),
+* [HTML IS a Programming Language (Imperative vs Declarative)](https://www.youtube.com/watch?v=4A2mWqLUpzw 
+  "HTML IS a Programming Language (Imperative vs Declarative) /no-iframe/"),
   `8:27`, [Computerphile](https://www.youtube.com/channel/UC9-y-6csu5WGm29I7JiwpnA),
   Jun 28 2016
 

--- a/topics/paradigms/03-proto/02-object-create/README.md
+++ b/topics/paradigms/03-proto/02-object-create/README.md
@@ -153,7 +153,8 @@ prototipos. Hoy en día `Object.create()` ya es parte del lenguaje en sí.
 
 Videos:
 
-* [Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46](https://www.youtube.com/watch?v=YkoelSTUy7A),
+* [Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46](https://www.youtube.com/watch?v=YkoelSTUy7A
+ "Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46 /no-iframe/"),
   `19:19`, [funfunfunction](https://www.youtube.com/channel/UCO1cgjhGzsSYb1rsB4bFe4Q),
   22 ago. 2016
 

--- a/topics/paradigms/03-proto/03-prototypal-inheritance/README.md
+++ b/topics/paradigms/03-proto/03-prototypal-inheritance/README.md
@@ -208,10 +208,12 @@ Videos:
 * Playlist: [Object Creation in JavaScript](https://www.youtube.com/playlist?list=PL0zVEGEvSaeHBZFy6Q8731rcwk0Gtuxub),
   `aprox. 3h`, [funfunfunction](https://www.youtube.com/channel/UCO1cgjhGzsSYb1rsB4bFe4Q),
   2016
-* [Prototypes in JavaScript - FunFunFunction #16](https://www.youtube.com/watch?v=riDVvXZ_Kb4),
+* [Prototypes in JavaScript - FunFunFunction #16](https://www.youtube.com/watch?v=riDVvXZ_Kb4 
+  "Prototypes in JavaScript - FunFunFunction #16 /no-iframe/"),
   `11:55`, [funfunfunction](https://www.youtube.com/channel/UCO1cgjhGzsSYb1rsB4bFe4Q),
   25 Jan 2016
-* [Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46](https://www.youtube.com/watch?v=YkoelSTUy7A),
+* [Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46](https://www.youtube.com/watch?v=YkoelSTUy7A
+  "Prototype basics - Object Creation in JavaScript P3 - FunFunFunction #46 /no-iframe/"),
   `19:19`, [funfunfunction](https://www.youtube.com/channel/UCO1cgjhGzsSYb1rsB4bFe4Q),
   22 ago. 2016
 

--- a/topics/prototyping/00-prototyping/00-wireframes/README.md
+++ b/topics/prototyping/00-prototyping/00-wireframes/README.md
@@ -67,4 +67,3 @@ prototipos de alta fidelidad.
 
 - [What Is The Difference Between Low-Fidelity and High-Fidelity Wireframes? - Prince Pal](https://think360studio.com/difference-low-fidelity-high-fidelity-wireframes/)
 - [What is a Wireframe: Designing Your UX Backbone - Jerry Cao](https://www.uxpin.com/studio/ui-design/what-is-a-wireframe-designing-your-ux-backbone/)
-- [Two Kinds of Prototyping](https://vimeo.com/212958691)

--- a/topics/ux-research/01-qualitative-research/00-interviews/README.md
+++ b/topics/ux-research/01-qualitative-research/00-interviews/README.md
@@ -352,4 +352,5 @@ Algunos consejos para tener en mente:
 - [How to hack your body language for better interviews](https://library.gv.com/how-to-hack-your-body-language-for-better-interviews-2b28b99ece6d)
 - [Get better data from user studies: 16 interviewing tips](https://library.gv.com/get-better-data-from-user-studies-16-interviewing-tips-328d305c3e37)
 - [How to Build Better Rapport For Better Research Interviews](https://library.gv.com/how-to-build-better-rapport-for-better-research-interviews-869952b6a71d)
-- [User Research, Quick 'n' Dirty](https://youtu.be/WpzmOH0hrEM?t=45m00s)
+- [User Research, Quick 'n' Dirty](https://youtu.be/WpzmOH0hrEM?t=45m00s
+  "User Research, Quick 'n' Dirty /no-iframe/")

--- a/topics/ux-research/03-synthesis/02-user-personas/README.md
+++ b/topics/ux-research/03-synthesis/02-user-personas/README.md
@@ -153,4 +153,4 @@ te podrían pasar cosas como esta:
 - [Getting From Research to Personas: Harnessing the Power of Data](https://www.cooper.com/journal/2002/11/getting_from_research_to_perso)
 - [Perfecting Your Personas](https://www.cooper.com/journal/2001/08/perfecting_your_personas)
 - [The origin of personas](https://www.cooper.com/journal/2008/5/the_origin_of_personas)
-- [Understanding Personas - An Interview with Alan Cooper](https://youtu.be/G7ljzXB40hw)
+- [Understanding Personas - An Interview with Alan Cooper](https://youtu.be/G7ljzXB40hw "Understanding Personas - An Interview with Alan Cooper /no-iframe/")


### PR DESCRIPTION
… want the parser to turn into iframes

@unjust este es un PR que va en conjunto con este otro PR del repo de `currículum-parser`, entre ambos solucionan el issue que habíamos conversado sobre no mostrar videos en _ciertas_ circunstancias, como en listas, funciona simplemente agregando un flag (`string`) `/no-iframe/` al final del atributo `título` de cada link y luego agregando esa condición a la función que transforma los links en `iframes`.

busqué todos los links que tuvieran la `string` "youtu" y "vimeo" y que fueran parte de un link en markdown que estuviera en una lista utilizando la siguiente expresión regular:

`(?:^[*-]\s*\[[^\]]+\]\((?:[^)]*(youtu|vimeo)[^)]*)\)|^\|\s*\[[^\]]+\]\((?:[^)]*(youtu|vimeo)[^)]*)\))`

espero no se me hayan escapado muchos otros casos :grin: 

entonces las listas que se veían así:

![Screenshot_2023-05-26_15-38-49](https://github.com/Laboratoria/bootcamp/assets/12631491/1b50d25a-f289-4116-8589-de72a6b5cf37)

con estos cambios ya se ven así:
![Screenshot_2023-05-26_15-39-45](https://github.com/Laboratoria/bootcamp/assets/12631491/f1636491-4ccc-4674-bd41-fea877e2aa5e)



