### PR TITLE
feat(TopBar): Quita título de menu de idioma

### DIFF
--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -99,9 +99,8 @@ const TopBar = () => {
                   value={lang}
                   onChange={e => navigate(`/${e.target.value}/${urlWithoutLang}`)}
                 >
-                  <MenuItem value="" disabled>Lang</MenuItem>
-                  <MenuItem value={'es'}>ES</MenuItem>
-                  <MenuItem value={'pt'}>PT</MenuItem>
+                  <MenuItem value="es">ES</MenuItem>
+                  <MenuItem value="pt">PT</MenuItem>
                 </Select>
               </FormControl>
             </Grid>


### PR DESCRIPTION
Ver https://github.com/Laboratoria/bootcamp.laboratoria.la/issues/256

En el próximo release de `bootcamp.laboratoria.la` se va a incluir este cambio, y toca replicarlo acá :stuck_out_tongue_winking_eye: 