### PR TITLE
fix(YML): Removes backticks from typescript/classes/this title in es and pt translations

### DIFF
--- a/learning-objectives/intl/es.yml
+++ b/learning-objectives/intl/es.yml
@@ -1222,7 +1222,7 @@ typescript/classes/static-members:
       url: https://www.typescriptlang.org/docs/handbook/2/classes.html#static-members
 
 typescript/classes/this:
-  title: `this`
+  title: this
   links:
     - title: Documentación oficial de Typescript
       url: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-at-runtime-in-classes

--- a/learning-objectives/intl/pt.yml
+++ b/learning-objectives/intl/pt.yml
@@ -1215,7 +1215,7 @@ typescript/classes/static-members:
       url: https://www.typescriptlang.org/docs/handbook/2/classes.html#static-members
 
 typescript/classes/this:
-  title: `this`
+  title: this
   links:
     - title: Documentação oficial do Typescript
       url: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-at-runtime-in-classes


### PR DESCRIPTION
Los backticks en los archivos de internacionalización de objetivos de aprendizaje estaba haciendo que el parser, al generar los proyectos, arrojara el siguiente error:

```
YAMLException: bad indentation of a mapping entry (1225:10)

 1222 |       url: https://www.typescriptlang.o ...
 1223 | 
 1224 | typescript/classes/this:
 1225 |   title: `this`
-----------------^
 1226 |   links:
 1227 |     - title: Documentación oficial de T ...
    at generateError (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:1273:10)
    at throwError (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:1277:9)
    at readBlockMapping (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2272:7)
    at composeNode (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2531:12)
    at readBlockMapping (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2254:11)
    at composeNode (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2531:12)
    at readDocument (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2715:3)
    at loadDocuments (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2778:5)
    at Object.load$1 [as load] (file:///home/user/Documents/laboratoria/bootcamp/node_modules/js-yaml/dist/js-yaml.mjs:2804:19)
    at loadYaml (file:///home/user/Documents/laboratoria/bootcamp/node_modules/@laboratoria/curriculum-parser/lib/project.js:28:8) {
  reason: 'bad indentation of a mapping entry',
```