### PR TITLE
fix: change regex for oa heading fixes #1506

### DIFF
--- a/scripts/create-cohort-project.mjs
+++ b/scripts/create-cohort-project.mjs
@@ -169,7 +169,7 @@ const addLocalizedLearningObjectives = async (repoDir, opts, meta) => {
   const startIndex = contents.findIndex(
     line => /^## \d+\. Objetivos de aprendiza(je|gem)/i.test(line),
   );
-    
+
   if (startIndex < 0) {
     throw new Error('README.md is missing Learning Objectives heading');
   }

--- a/scripts/create-cohort-project.mjs
+++ b/scripts/create-cohort-project.mjs
@@ -167,9 +167,9 @@ const addLocalizedLearningObjectives = async (repoDir, opts, meta) => {
   const readmePath = path.join(repoDir, 'README.md');
   const contents = (await readFile(readmePath, 'utf8')).split('\n');
   const startIndex = contents.findIndex(
-    line => /^## \d\. Objetivos de aprendiza(je|gem)/i.test(line),
+    line => /^## \d+\. Objetivos de aprendiza(je|gem)/i.test(line),
   );
-
+    
   if (startIndex < 0) {
     throw new Error('README.md is missing Learning Objectives heading');
   }


### PR DESCRIPTION
Cambia el regex para buscar numbers > 9.

Antes el script tira un error por `10. Objetivos de aprendizaje` en Text Analyzer.

Hay que escribir tests en curriculum-parser para avisar de eso.